### PR TITLE
chore: Dependabot PR 제목 한글화 워크플로를 추가한다

### DIFF
--- a/.github/workflows/dependabot-korean-title.yml
+++ b/.github/workflows/dependabot-korean-title.yml
@@ -1,0 +1,92 @@
+name: Dependabot PR 제목 한글화
+
+# Dependabot이 여는 PR의 제목은 GitHub 쪽 고정 템플릿이라 언어 설정이 없다.
+# 그래서 PR이 열릴 때 제목만 규칙 기반으로 한글로 다시 쓰고, 본문 맨 위에
+# 한 줄 요약만 덧붙인다. 본문(릴리스 노트·커밋 로그)은 원문 그대로 둔다 —
+# 전체 번역을 하려면 번역 API 호출과 시크릿 등록이 필요해서 범위를 좁혔다.
+#
+# PR 코드는 체크아웃하지 않고 gh CLI로 메타데이터만 수정하므로, 외부 액션
+# 의존 없이(S9 SHA 고정 대상 자체가 없음) GitHub 기본 제공 러너 도구만 쓴다.
+#
+# Dependabot PR은 fork가 아니라 이 저장소 안의 브랜치(dependabot/...)라서
+# pull_request_target 없이 일반 pull_request 트리거로도 쓰기 권한 토큰을
+# 받을 수 있다. 굳이 필요 없는 권한 상승 트리거를 쓰지 않는다.
+
+on:
+  pull_request:
+    types: [opened, reopened]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dependabot-korean-title-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  rewrite-title:
+    # Dependabot이 연 PR에만 반응한다. 사람이 연 PR은 건드리지 않는다.
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    env:
+      GH_TOKEN: ${{ github.token }}
+      REPO: ${{ github.repository }}
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+      PR_TITLE: ${{ github.event.pull_request.title }}
+      HEAD_REF: ${{ github.event.pull_request.head.ref }}
+    steps:
+      - name: 제목을 한글로 다시 쓰고 본문에 요약 한 줄 추가
+        run: |
+          set -euo pipefail
+
+          # 브랜치 이름으로 어떤 종류의 업데이트인지 구분한다.
+          # (dependabot/npm_and_yarn/..., dependabot/github_actions/..., dependabot/docker/...)
+          case "$HEAD_REF" in
+            dependabot/npm_and_yarn/*) TAG="[의존성]" ;;
+            dependabot/github_actions/*) TAG="[GitHub Actions]" ;;
+            dependabot/docker/*) TAG="[Docker]" ;;
+            *) TAG="[의존성]" ;;
+          esac
+
+          NEW_TITLE=""
+          SUMMARY_LINE=""
+
+          # 단일 패키지 버전업: "build(deps[-dev]): Bump X[ in DIR] from A to B"
+          # (Docker 생태계는 "Bump alpine in /backend from 3.19 to 3.20"처럼
+          # "in DIR"가 from 앞에 온다.)
+          if [[ "$PR_TITLE" =~ ^build\((deps|deps-dev)\):\ Bump\ ([^ ]+)(\ in\ ([^ ]+))?\ from\ ([^ ]+)\ to\ ([^ ]+)$ ]]; then
+            PKG="${BASH_REMATCH[2]}"
+            DIR="${BASH_REMATCH[4]:-}"
+            FROM="${BASH_REMATCH[5]}"
+            TO="${BASH_REMATCH[6]}"
+            if [[ -n "$DIR" ]]; then
+              NEW_TITLE="${TAG} ${PKG} (${DIR}) ${FROM} → ${TO} 업데이트"
+            else
+              NEW_TITLE="${TAG} ${PKG} ${FROM} → ${TO} 업데이트"
+            fi
+            SUMMARY_LINE="📦 의존성 \`${PKG}\`를 \`${FROM}\`에서 \`${TO}\`로 업데이트합니다."
+
+          # 그룹 업데이트: "build(deps[-dev]): Bump the GROUP group ... with N update(s)"
+          elif [[ "$PR_TITLE" =~ ^build\((deps|deps-dev)\):\ Bump\ the\ ([^ ]+)\ group(\ across\ [0-9]+\ director(y|ies))?\ with\ ([0-9]+)\ update ]]; then
+            GROUP="${BASH_REMATCH[2]}"
+            COUNT="${BASH_REMATCH[5]}"
+            NEW_TITLE="${TAG} ${GROUP} 그룹 ${COUNT}건 업데이트"
+            SUMMARY_LINE="📦 의존성 그룹 \`${GROUP}\`에서 ${COUNT}건을 업데이트합니다."
+          fi
+
+          if [[ -z "$NEW_TITLE" ]]; then
+            echo "제목 패턴을 인식하지 못해 건드리지 않는다: $PR_TITLE"
+            exit 0
+          fi
+
+          echo "새 제목: $NEW_TITLE"
+          gh pr edit "$PR_NUMBER" --repo "$REPO" --title "$NEW_TITLE"
+
+          # 이미 요약 줄이 붙어 있으면(재실행 등) 중복으로 덧붙이지 않는다.
+          CURRENT_BODY="$(gh pr view "$PR_NUMBER" --repo "$REPO" --json body -q .body)"
+          if [[ "$CURRENT_BODY" != *"$SUMMARY_LINE"* ]]; then
+            { printf '%s\n\n---\n\n' "$SUMMARY_LINE"; printf '%s' "$CURRENT_BODY"; } \
+              | gh pr edit "$PR_NUMBER" --repo "$REPO" --body-file -
+          fi

--- a/docs/policy/supply-chain-security.md
+++ b/docs/policy/supply-chain-security.md
@@ -34,6 +34,12 @@ SHA를 최신으로 유지하는 비용은 Dependabot의 `github-actions` 항목
 워크플로 토큰 권한(`permissions:`)도 기본을 `contents: read`로 좁힌다. 배포·퍼블리시 잡을 추가할
 때만 필요한 권한을 그 잡에만 준다.
 
+### Dependabot PR 제목 한글화
+
+Dependabot이 여는 PR의 제목·본문은 GitHub 쪽 고정 템플릿이라 언어를 바꿀 수 없다. `.github/workflows/dependabot-korean-title.yml`이 PR이 열릴 때 제목만 규칙 기반으로 한글로 다시 쓰고, 본문 맨 위에 한 줄 요약을 덧붙인다. 본문 원문(릴리스 노트·커밋 로그)은 그대로 둔다 — 전체 번역은 번역 API 호출과 시크릿 등록이 필요해 범위에서 뺐다.
+
+이 워크플로는 PR 코드를 체크아웃하지 않고 `gh` CLI로 메타데이터만 수정하므로 외부 액션에 의존하지 않는다(SHA 고정 대상 자체가 없다). Dependabot PR은 fork가 아니라 저장소 내 브랜치라서 `pull_request_target` 같은 권한 상승 트리거 없이 일반 `pull_request` 트리거로 충분하다.
+
 ### S6의 한계를 알고 쓰라
 
 Node의 permission model은 최신 버전에서 experimental을 졸업해 쓸 만해졌다. 하지만 DITTER는 SQLite 파일 쓰기와 PostgreSQL·AI API 네트워크가 필수라 결국 플래그를 넓게 열어야 한다. 특히 **`--allow-net`은 특정 호스트로 제한할 수 없다.** 즉 "침해된 패키지가 데이터를 외부로 빼돌리는" 시나리오는 이 플래그로 못 막는다. **부분 완화이지 해결책이 아니다.**


### PR DESCRIPTION
## 변경 요약

- Dependabot이 여는 PR의 제목을 규칙 기반으로 한글로 다시 쓰는 워크플로(`.github/workflows/dependabot-korean-title.yml`)를 추가한다.
  - Dependabot 제목은 GitHub 쪽 고정 템플릿이라 언어 설정이 없어서, PR이 열릴 때(`opened`/`reopened`) `dependabot[bot]`이 작성한 PR만 골라 제목을 파싱해 한글로 재작성한다.
  - 본문은 맨 위에 한 줄 요약만 붙이고, 릴리스 노트·커밋 로그 같은 원문은 그대로 둔다 — 전체 번역은 번역 API 호출과 시크릿 등록이 필요해 범위 밖으로 뺐다.
  - PR 코드는 체크아웃하지 않고 `gh` CLI로 메타데이터만 수정한다. 외부 액션 의존이 없다(SHA 고정 대상 자체가 없음).
  - Dependabot 브랜치는 fork가 아니라 저장소 내 브랜치라, `pull_request_target` 같은 권한 상승 트리거 없이 일반 `pull_request` 트리거로 충분하다.
- `docs/policy/supply-chain-security.md`의 S9(GitHub Actions 고정) 섹션 뒤에 위 워크플로의 동작과 설계 이유를 기록한다.
- 이미 열려 있던 Dependabot PR #3~#9 제목·본문도 동일 규칙으로 수동 재작성했다(워크플로는 `opened`/`reopened` 시점부터만 적용되므로 기존 PR은 소급 적용되지 않음).

## 테스트 방법

- `frontend/`·`backend/`·`packages/` 변경이 없어 워크스페이스 테스트는 해당 없음(건너뜀).
- 워크플로의 제목 파싱 정규식을 로컬 `bash`로 실제 저장소의 Dependabot PR 제목 7건(#3~#9) 전체에 대해 검증 — 전부 의도한 한글 제목으로 정확히 변환됨을 확인.
- YAML 문법: `ruby -ryaml -e "YAML.load_file(...)"`로 파싱 성공 확인(actionlint 미설치 환경).

## 코드리뷰

**이번 review 요약**: 2사이클 모두 CLEAN — 확정 수정 0건, 이월 2건 (P3, 확신 낮음).

### 알려진 제약 사항 (이번 PR 미반영, 후속 검토 필요)

#### 1. Dependabot actor 검증이 문자열 비교 하나에만 의존

- **위치**: `.github/workflows/dependabot-korean-title.yml:24`
- **문제**: `if: github.actor == 'dependabot[bot]'` 문자열 비교만으로 쓰기 권한 게이트를 건다. 이 계정명은 사실상 위조 불가능하지만, 숫자 actor id(49699333)로 이중 확인하는 방어심층 장치는 없다.
- **왜 이번 PR 에 안 넣었나**: 실질 악용 가능성을 실증할 방법이 없는 이론적 제안이라 확신이 낮다(P3).

#### 2. Docker 생태계 제목 파싱 순서가 실제 사례로 검증되지 않음

- **위치**: `.github/workflows/dependabot-korean-title.yml:47`
- **문제**: `"Bump PKG in DIR from A to B"` 순서를 가정해 정규식을 짰지만, `/backend`·`/frontend`가 아직 STEP 0 상태라 Docker Dependabot PR이 한 건도 발생한 적이 없어 이 가정을 실제 예시로 검증하지 못했다.
- **왜 이번 PR 에 안 넣었나**: 매칭 실패 시에도 원본 제목을 그대로 두는 안전한 no-op이라 급하지 않다. 첫 Docker Dependabot PR이 열리면 그때 실제 제목으로 확인한다.
