### PR TITLE
docs: README 시작하기 절에서 /dev 커맨드를 안내한다

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,11 +55,21 @@ docs/                     계획·정책·컨벤션·스키마
 ```bash
 npm ci --ignore-scripts   # 설치 스크립트 차단이 기본이다 (docs/policy/supply-chain-security.md S5)
 cp .env.example .env
+```
+
+이후 로컬 개발 서버(백엔드 `:4000` + 프런트 `:5173` + 로컬 PostgreSQL)는 Claude Code에서
+[`/dev`](.claude/commands/dev.md) 커맨드로 기동·재시작한다. 기존 서버 종료 → DB 컨테이너 확인/기동
+→ `npm run dev` → 포트 확인까지 한 번에 처리한다.
+
+커맨드 없이 수동으로 하는 경우:
+
+```bash
 docker compose up -d db   # 로컬 PostgreSQL
 npm run dev               # 백엔드 :4000 + 프런트 :5173
 ```
 
-`docker compose up` 한 줄이면 DB·백엔드·프런트가 한 번에 뜬다. 일상 개발에서는 DB만 컨테이너로
+`docker compose up` 한 줄이면 DB·백엔드·프런트가 한 번에 뜬다. 단 이건 위 절차와 배타적인 별개
+모드다 — 이 경우 `npm run dev`는 실행하지 않는다(포트가 겹친다). 일상 개발에서는 DB만 컨테이너로
 띄우고 앱은 호스트에서 `npm run dev`로 돌리는 쪽이 빠르다.
 
 개발 서버는 **기본적으로 내 컴퓨터에서만 접속을 받는다.** 같은 네트워크의 다른 기기에서 붙어야


### PR DESCRIPTION
## 변경 요약

- README `시작하기` 절이 로컬 개발 서버 기동을 `docker compose up -d db` + `npm run dev` 수동 절차로만 안내하고 있었는데, 실제로는 서버 종료·DB 컨테이너 확인/기동·포트 확인까지 처리하는 Claude Code `/dev` 커맨드([.claude/commands/dev.md](.claude/commands/dev.md))가 이미 있어 이를 기본 경로로 안내하도록 갱신했다.
- 커맨드 없이 수동으로 진행하는 절차는 대안으로 남겨뒀다.
- `docker compose up`(앱까지 컨테이너로 전부 띄우는 모드)과 `npm run dev`(호스트 직접 실행)를 섞으면 포트가 겹친다는 경고를 명시했다 — `/dev` 커맨드 문서의 동일한 경고와 맞춘 것이다.

## 테스트 방법

- `docs/`(문서) 전용 변경이라 워크스페이스 테스트는 건너뛰었다 ([.claude/commands/pr.md](.claude/commands/pr.md) §3 규칙).
- `/review` 1사이클(reviewer 서브에이전트) 실행 — status `CLEAN`, finding 0건, 이월 0건. `/dev` 문서의 절차 설명과 `docker-compose.yml`의 포트 바인딩을 대조해 새 README 문구가 사실과 일치함을 확인했다.

## 관련 이슈/맥락

없음 — 대화 중 README를 현행화하다가 로컬 실행 안내를 프로젝트의 `/dev` 커맨드 경로로 맞추자는 요청에 따른 후속 수정이다.
