### PR TITLE
fix: high 등급 npm advisory 두 건을 해소한다

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1769,9 +1769,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2264,9 +2264,9 @@
       }
     },
     "node_modules/fast-json-stringify/node_modules/ajv/node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",
@@ -2280,9 +2280,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/fast-json-stringify/node_modules/fast-uri": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-4.1.1.tgz",
-      "integrity": "sha512-YPOs1zD5TG2+EZt+r88LwF6mclA7TPkpwMP7ZN3TO2HiHS8TXvq7QA/17iJsV9dubcLo/f8eEYqMBruyQV21hQ==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-4.1.2.tgz",
+      "integrity": "sha512-TyGmBcbDTZXcb2cj5MV89DrF42DKvb3y5DDUNh95iO+IMeAzMkVSxK1PZRrRIpc9yg8U2GhGdbofNa0LS/a4Bw==",
       "funding": [
         {
           "type": "github",
@@ -2318,9 +2318,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## 무엇을 바꿨나

`npm audit --audit-level=high` 게이트가 걸린 high 등급 advisory 두 건을 해소합니다.
`package-lock.json`만 바뀝니다.

- `brace-expansion` 5.0.8 → 5.0.9 ([GHSA-rgw5-rvv9-x895](https://github.com/advisories/GHSA-rgw5-rvv9-x895), DoS)
- `fast-uri` 3.1.4 → 3.1.5, 4.1.1 → 4.1.2 ([GHSA-7p8r-x3mc-p8w7](https://github.com/advisories/GHSA-7p8r-x3mc-p8w7), host confusion)

둘 다 전이 의존성이라 `package.json`은 건드리지 않았습니다.

## 왜

8/3 마지막 초록 CI 이후 공개된 advisory라 main의 CI가 빨간 상태였습니다(`npm ci` →
`npm audit --audit-level=high`에서 exit 1). PR #17의 diff와는 무관하지만, 그 PR도
같은 CI 게이트를 걸어야 해서 이 수정을 먼저 별도 PR로 분리했습니다.

## 확인한 것

lockfile을 처음 `npm update`로 갱신했을 때 node 22/npm 10 환경이라 `libc` 필드
(gnu/musl 판별자) 10개가 부수적으로 삭제되는 문제가 있었습니다 — 이 저장소의
`frontend/Dockerfile`·`backend/Dockerfile`이 둘 다 `node:26-alpine`(musl)에서
`npm ci`를 실행하므로, 이 필드가 없으면 이미지에 불필요한 gnu 바이너리가 섞여
들어갈 수 있습니다. `.nvmrc`가 지정하는 node 26 / npm 11로 다시 생성해 해결했습니다.

```
node 26.7.0 / npm 11.19.0 (.nvmrc 기준)
npm ci --ignore-scripts            → 성공
npm audit --audit-level=high       → found 0 vulnerabilities
npm run lint                       → 클린
npm run typecheck                  → 클린 (backend · frontend)
npm test                           → 2 파일 / 8 테스트 통과

diff 범위 검증: 4개 패키지 블록의 version/resolved/integrity 12줄 교체로 한정
                (libc 등 다른 필드 변화 없음), package.json 변경 0
```

- [x] `npm run lint` / `npm run typecheck` / `npm test` 통과
- [x] 변경한 영역을 실제로 실행해 확인 — `npm ci`부터 다시 설치해 재현 검증

## 체크리스트

- [x] 커밋을 영역별로 분리했다 — 루트 `package-lock.json` 단독 변경, 영역 밖 경로라
      그 목적 하나에 맞춰 별도 커밋 ([commit-convention.md](docs/conventions/commit-convention.md))
- [x] 정책·설계가 바뀌었다면 `docs/`를 함께 갱신했다 — 해당 없음(설계 변경 없음)
- [x] 읽기 전용 경계를 건드렸다면 2인 리뷰를 받았다 — 해당 없음(코드 변경 없음)
- [x] 새 의존성을 추가했다면 "직접 짤 수 있나"를 먼저 검토했다 — 새 의존성 없음,
      기존 전이 의존성의 패치 버전 상향뿐

## 코드리뷰

**이번 review 요약**: reviewer 서브에이전트를 3사이클 돌렸습니다. 사이클 1에서 P2 1건을
찾아(아래 참고) 확정 수정했고, 사이클 2·3은 CLEAN입니다. 이월 항목 없음.

### 알려진 제약 사항

이번 PR에서 전부 해소되어 이월 항목이 없습니다. 참고로 사이클 1이 잡은 문제와 조치만
기록합니다 — `libc` 필드 유실(P2, bug)은 node 22/npm 10으로 갱신한 최초 커밋에서
발생했고, node 26/npm 11로 재생성한 뒤 사이클 2에서 해소를 재검증했습니다.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DDNsXTgzTti7H7Ssp7ZVfc)_