### PR TITLE
fix: 백엔드 개발 워처의 재시작 경합을 고친다

### DIFF
--- a/backend/scripts/dev-watch.mjs
+++ b/backend/scripts/dev-watch.mjs
@@ -74,15 +74,29 @@ function scheduleRestart() {
  * doRestart 를 큐에 잇는다. `.then` 체이닝이라, 지금 진행 중인 재시작(이전 프로세스
  * 종료 대기 포함)이 끝난 뒤에만 다음 재시작이 시작된다 — 겹쳐 부르면 새 프로세스
  * 두 개가 같은 포트를 놓고 다툰다.
+ *
+ * `.then(fn, onRejected)` 가 아니라 `.then(fn).catch(onRejected)` 를 쓴다. 전자의
+ * onRejected 는 **restartQueue(이전 상태)가 reject 됐을 때만** 불리고 `fn`(doRestart)
+ * 자신이 던진 예외는 못 잡는다 — 그러면 이번 재시작의 오류를 다음 재시작 요청이 대신
+ * 삼켜 조용히 스킵된다.
  */
 function enqueueRestart() {
-  restartQueue = restartQueue.then(doRestart, (err) => {
+  restartQueue = restartQueue.then(doRestart).catch((err) => {
     console.error('[dev-watch] 재시작 중 오류:', err);
   });
 }
 
-/** 프로세스에 SIGTERM 을 보내고 완전히 종료될 때까지 기다린다. */
+/**
+ * 프로세스에 SIGTERM 을 보내고 완전히 종료될 때까지 기다린다.
+ *
+ * 이미 종료된 프로세스면 곧바로 통과시킨다 — `exit` 이벤트는 한 번만 발생하고
+ * EventEmitter 는 지나간 이벤트를 새로 등록한 리스너에 재생해주지 않는다. 백엔드가
+ * 스스로 죽은 뒤(문법 오류 등) 다음 저장에서 이 함수가 그 죽은 프로세스를 다시
+ * 기다리면, `once('exit', ...)` 도 `SIGKILL` 폴백(이미 죽은 프로세스에는 아무 효과가
+ * 없다)도 절대 풀리지 않아 재시작 큐 전체가 영구히 멈춘다.
+ */
 function waitForExit(proc) {
+  if (proc.exitCode !== null || proc.signalCode !== null) return Promise.resolve();
   return new Promise((resolve) => {
     intentionalKills.add(proc);
     const killTimer = setTimeout(() => proc.kill('SIGKILL'), KILL_TIMEOUT_MS);

--- a/backend/scripts/dev-watch.mjs
+++ b/backend/scripts/dev-watch.mjs
@@ -20,13 +20,22 @@ const ENTRY = path.join(SRC, 'index.ts');
 const POLL_INTERVAL_MS = 300;
 // 저장 한 번이 여러 이벤트로 쪼개져 오는 경우를 한 번의 재시작으로 묶는다.
 const DEBOUNCE_MS = 100;
+// SIGTERM 을 받고도 안 죽는 프로세스가 있으면 이 시간 뒤 SIGKILL 로 강제 종료한다.
+// 없으면 워처가 무한정 기다려 재시작이 멈춘다.
+const KILL_TIMEOUT_MS = 5000;
 
 /** @type {import('node:child_process').ChildProcess | null} */
 let child = null;
 let restartTimer = null;
+// 재시작을 순서대로만 실행되게 하는 큐. 겹쳐 실행되면 이전 프로세스가 아직 포트를
+// 붙잡고 있는 동안 새 프로세스가 뜨려다 죽는 경합이 생긴다 (doRestart 주석 참고).
+let restartQueue = Promise.resolve();
 /** @type {string[]} */
 let watched = [];
 let shuttingDown = false;
+// waitForExit 로 우리가 의도적으로 종료시키는 중인 프로세스 집합. 재시작으로 죽인
+// 것과 프로세스가 스스로 죽은 것을 구분하는 데 쓴다.
+const intentionalKills = new WeakSet();
 
 /**
  * `src` 아래의 `.ts` 파일과 디렉토리를 모두 모은다. 디렉토리까지 보는 이유는 파일이 새로
@@ -57,12 +66,40 @@ function scheduleRestart() {
   clearTimeout(restartTimer);
   restartTimer = setTimeout(() => {
     console.log('[dev-watch] 변경 감지 — 백엔드를 다시 띄운다');
-    start();
+    enqueueRestart();
   }, DEBOUNCE_MS);
 }
 
-function start() {
-  child?.kill('SIGTERM');
+/**
+ * doRestart 를 큐에 잇는다. `.then` 체이닝이라, 지금 진행 중인 재시작(이전 프로세스
+ * 종료 대기 포함)이 끝난 뒤에만 다음 재시작이 시작된다 — 겹쳐 부르면 새 프로세스
+ * 두 개가 같은 포트를 놓고 다툰다.
+ */
+function enqueueRestart() {
+  restartQueue = restartQueue.then(doRestart, (err) => {
+    console.error('[dev-watch] 재시작 중 오류:', err);
+  });
+}
+
+/** 프로세스에 SIGTERM 을 보내고 완전히 종료될 때까지 기다린다. */
+function waitForExit(proc) {
+  return new Promise((resolve) => {
+    intentionalKills.add(proc);
+    const killTimer = setTimeout(() => proc.kill('SIGKILL'), KILL_TIMEOUT_MS);
+    proc.once('exit', () => {
+      clearTimeout(killTimer);
+      resolve();
+    });
+    proc.kill('SIGTERM');
+  });
+}
+
+async function doRestart() {
+  // 이전 프로세스가 완전히 종료된 뒤에만 새 프로세스를 띄운다. 그러지 않으면 이전
+  // 프로세스가 아직 포트를 붙잡고 있는 상태에서 새 프로세스가 EADDRINUSE 로 죽는데,
+  // 워처는 "종료됐다"고만 적고 다음 저장까지 가만히 있어 백엔드가 죽은 줄 모르게 된다.
+  if (child) await waitForExit(child);
+
   // 새 파일이 생겼을 수 있으므로 재시작마다 감시 목록을 다시 만든다.
   rewatch();
 
@@ -73,10 +110,11 @@ function start() {
   child = proc;
 
   proc.on('exit', (code, signal) => {
-    // `child !== proc` 이면 우리가 교체한 것이다. 같으면 서버가 스스로 죽었다는 뜻 —
-    // 워처는 살려 둔다. 문법 오류를 고치면 다음 저장에서 다시 뜬다. 여기서 같이 죽으면
-    // 컨테이너가 재시작 루프에 빠져 로그에서 원인을 읽기 어려워진다.
-    if (shuttingDown || child !== proc) return;
+    // 재시작으로 우리가 죽인 것이면(intentionalKills) 조용히 넘어간다. 아니면 서버가
+    // 스스로 죽은 것이다 — 워처는 살려 둔다. 문법 오류를 고치면 다음 저장에서 다시
+    // 뜬다. 여기서 같이 죽으면 컨테이너가 재시작 루프에 빠져 로그에서 원인을 읽기
+    // 어려워진다.
+    if (shuttingDown || intentionalKills.has(proc)) return;
     console.error(
       `[dev-watch] 백엔드가 종료됐다 (code=${code}, signal=${signal}). 변경을 기다린다`,
     );
@@ -92,4 +130,4 @@ for (const signal of ['SIGTERM', 'SIGINT']) {
 }
 
 console.log(`[dev-watch] ${SRC} 를 ${POLL_INTERVAL_MS}ms 간격으로 폴링한다`);
-start();
+enqueueRestart();


### PR DESCRIPTION
## 변경 요약

[#20](https://github.com/SurvivorsStudio/ditter/pull/20)에서 이월했던 후속 항목 1번 — `backend/scripts/dev-watch.mjs`의 재시작 경합을 고친다.

- **원래 문제**: 재시작할 때 이전 프로세스에 SIGTERM만 보내고 곧바로 새 프로세스를 띄웠다. 이전 프로세스가 아직 포트를 붙잡고 있으면 새 프로세스가 EADDRINUSE로 죽는데, 워처는 "종료됐다"고만 적고 다음 저장까지 가만히 있어 백엔드가 꺼진 줄 모르게 된다.
- `waitForExit()`로 이전 프로세스의 실제 종료(`exit` 이벤트)를 기다린 뒤에만 새 프로세스를 띄운다. SIGTERM을 무시하는 프로세스에 대비해 5초 뒤 SIGKILL로 강제 종료하는 안전장치를 둔다.
- 재시작 호출을 `restartQueue`(Promise 체인)로 순서대로만 실행되게 한다. 겹쳐 부르면(예: 종료가 오래 걸리는 동안 또 저장한 경우) 새 프로세스 두 개가 같은 포트를 놓고 다툴 수 있다.
- "우리가 죽인 것"과 "프로세스가 스스로 죽은 것"을 구분하는 기준을 바깥 변수 비교(`child !== proc`)에서 `WeakSet`(`intentionalKills`)으로 바꾼다.

## 테스트 방법

- `npm run format:check` / `npm run lint` / `npm run typecheck` / `npm test --workspace=backend` — 전부 통과.
- 실제 컨테이너에서 세 가지 시나리오를 재현:
  1. **정상 재시작(회귀 확인)**: 소스 수정 → 5초 내 재기동, health 200.
  2. **느린 종료**: `index.ts`의 SIGTERM 핸들러에 2초 인위 지연을 넣고 재시작 트리거 → 정확히 그 시간만큼 기다린 뒤 새 프로세스가 뜨고, EADDRINUSE·거짓 크래시 로그 없음(로그 타임스탬프로 확인).
  3. **SIGTERM 무시**: SIGTERM을 무시하도록 만들고 재시작 트리거 → 정확히 5초(`KILL_TIMEOUT_MS`) 뒤 SIGKILL로 강제 종료, 새 프로세스 정상 기동.

## 코드리뷰

**이번 review 요약**: 1사이클 진행 — 발견 3건 중 2건 사용자 확정 수정, 1건 스킵(낮은 위험도, 아래 참고). 이월 0건.

리뷰 과정에서 첫 수정안 자체에 있던 **P0 버그**가 잡혔다: 백엔드가 스스로 크래시(문법 오류 등)한 뒤 고쳐서 저장하면, `waitForExit()`가 이미 종료된 프로세스의 `exit` 이벤트를 다시 기다리는데 — `EventEmitter`는 지나간 이벤트를 새 리스너에 재생해주지 않고 SIGKILL 폴백도 이미 죽은 프로세스엔 효과가 없어 — 재시작 큐 전체가 영구히 멈춘다. 실제 컨테이너에서 재현 확인(크래시 → 수정 → 15초 넘게 응답 없음) 후, `waitForExit()` 맨 앞에 "이미 종료됐으면 곧바로 통과" 가드(`proc.exitCode`/`proc.signalCode` 확인)를 추가해 해소하고 같은 시나리오로 재검증했다.

함께 잡힌 P2: `enqueueRestart()`의 `.then(fn, onRejected)` 패턴은 `doRestart` 자신이 던진 예외를 못 잡아, 재시작 하나가 실패하면 그 다음 저장이 조용히 스킵된다. `.then(fn).catch(onRejected)`로 교체하고 격리 스크립트로 검증했다.

스킵 처리한 항목(P3, 별도 조치 없음): 워처 자체의 `SIGTERM`/`SIGINT` 핸들러가 자식 프로세스 종료를 기다리지 않고 바로 `process.exit(0)`한다. 컨테이너 런타임이 같은 cgroup의 자식을 정리해주는 게 일반적이라 실질 위험이 낮다고 판단했다.
