### PR TITLE
fix: README 접속 주소 표기를 127.0.0.1로 통일한다

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,9 +96,9 @@ docker compose up
 
 | 주소 | 무엇 |
 |---|---|
-| http://localhost:5173 | 웹 콘솔 (React + Vite) |
-| http://localhost:4000 | 백엔드 API (Fastify) |
-| `localhost:5432` | PostgreSQL — psql·GUI 클라이언트로 붙을 때 쓴다 |
+| http://127.0.0.1:5173 | 웹 콘솔 (React + Vite) |
+| http://127.0.0.1:4000 | 백엔드 API (Fastify) |
+| `127.0.0.1:5432` | PostgreSQL — psql·GUI 클라이언트로 붙을 때 쓴다 |
 
 **소스는 bind mount라 고치면 바로 반영된다.** 프런트는 HMR로, 백엔드는 프로세스 재시작으로
 붙는다. 이미지를 다시 빌드해야 하는 건 **의존성이 바뀔 때뿐**이다 — 그때는


### PR DESCRIPTION
## 변경 요약

[#20](https://github.com/SurvivorsStudio/ditter/pull/20)에서 이월했던 후속 항목 2번 — README 접속 주소 표기가 `localhost`와 `127.0.0.1`로 혼재하던 문제를 고친다.

- 「시작하기」 절 주소 표(웹 콘솔·백엔드 API·PostgreSQL) 세 줄을 `localhost` → `127.0.0.1`로 통일한다. 컨테이너 포트는 `docker-compose.yml`의 `ports`가 `127.0.0.1:PORT:PORT`로만 바인딩하는데, `localhost`를 IPv6(`::1`)로 먼저 해석하는 환경에서는 연결이 거부될 수 있다.
- `.claude/commands/dev.md`·`docker-compose.yml`은 이미 `127.0.0.1`로 일관되게 쓰고 있어 README만 맞췄다.
- `.env.example`의 `POSTGRES_HOST=localhost`는 건드리지 않았다 — 호스트에서 직접 `npm run dev`로 돌릴 때 쓰는 DB 연결 문자열이라 다른 맥락이고, 주석으로 의도가 이미 명시돼 있다.

## 테스트 방법

- `README.md` 전체에 `localhost` 문자열이 더 이상 없음을 grep으로 확인.
- 문서 전용 변경이라 별도 테스트 스크립트 없음 (커밋 컨벤션 §변경 영역 테스트 — `docs/`만 변경 시 건너뛴다).

## 코드리뷰

**이번 review 요약**: 1사이클, CLEAN — 발견 0건.
