### PR TITLE
fix: 리눅스에서 컨테이너 uid와 저장소 소유자가 다를 때 쓰기가 막히는 문제를 고친다

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,8 +7,8 @@
 #   2) 호스트에서 직접 `npm run dev` 로 돌릴 때 (README 「호스트에서 직접 돌리기」)
 #   3) 리눅스에서 컨테이너가 bind mount 에 못 쓸 때 (아래 DEV_UID·DEV_GID)
 
-# 리눅스 전용: 컨테이너(uid:gid 1000:1000 고정)와 호스트 저장소 소유자가 다르면 bind
-# mount 쓰기가 막혀 프런트가 기동하지 못할 수 있다 (docker-compose.yml 의 `user:` 주석
+# 리눅스 전용: 컨테이너 기본 uid:gid(1000:1000)와 호스트 저장소 소유자가 다르면 bind
+# mount 쓰기가 막혀 프런트가 기동하지 못할 수 있다 (docker-compose.yml 의 DEV_UID 주석
 # 참고). `id -u`·`id -g` 로 확인한 값을 넣는다. macOS·Windows 는 보통 필요 없다.
 # DEV_UID=1000
 # DEV_GID=1000

--- a/.env.example
+++ b/.env.example
@@ -2,9 +2,16 @@
 # docs/policy/credential-management.md — 실제 자격증명은 저장소에 들어가지 않는다.
 #
 # `.env` 는 없어도 된다. `docker compose up` 은 docker-compose.yml 의 기본값으로 그대로 돈다.
-# 이 파일이 필요한 경우는 둘뿐이다:
+# 이 파일이 필요한 경우는 셋뿐이다:
 #   1) 기본 포트·DB 이름이 다른 것과 겹쳐서 바꿔야 할 때 (아래 POSTGRES_* 는 compose 도 읽는다)
 #   2) 호스트에서 직접 `npm run dev` 로 돌릴 때 (README 「호스트에서 직접 돌리기」)
+#   3) 리눅스에서 컨테이너가 bind mount 에 못 쓸 때 (아래 DEV_UID·DEV_GID)
+
+# 리눅스 전용: 컨테이너(uid:gid 1000:1000 고정)와 호스트 저장소 소유자가 다르면 bind
+# mount 쓰기가 막혀 프런트가 기동하지 못할 수 있다 (docker-compose.yml 의 `user:` 주석
+# 참고). `id -u`·`id -g` 로 확인한 값을 넣는다. macOS·Windows 는 보통 필요 없다.
+# DEV_UID=1000
+# DEV_GID=1000
 
 # 백엔드 — 호스트에서 직접 돌릴 때만 쓰인다.
 # 기본은 내 컴퓨터에서만 접속을 받는다. 같은 네트워크의 다른 기기에서 붙어야 할 때만

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -23,5 +23,17 @@ COPY --chown=node:node backend backend
 
 RUN npm run build --workspace=packages/shared-types
 
+# docker-compose.yml 이 `packages/shared-types/dist` 를 익명 볼륨으로 선언한다(호스트
+# bind mount 가 컨테이너 산출물을 가리지 않게). 그 볼륨은 지금 이 시점의 소유권(node,
+# uid 1000)을 그대로 물려받아 초기화되는데, 컨테이너를 다른 uid(`DEV_UID` — 리눅스에서
+# 호스트 소유자와 맞추는 값)로 띄우면 그 uid 가 못 쓴다 — 컨테이너가 뜰 때마다 이 build 를
+# 다시 돌리므로 매번 걸린다. 어떤 uid 로 뜨더라도 쓸 수 있게 미리 열어 둔다.
+#
+# `backend/node_modules`·`packages/shared-types/node_modules` 도 같은 이유로 익명
+# 볼륨이지만 여기서는 손대지 않는다 — npm 워크스페이스가 의존성을 루트 node_modules 로
+# 전부 호이스팅해서 이 경로 자체가 이미지 안에 존재하지 않고(런타임에 빈 디렉터리로
+# 새로 생긴다), 아무도 거기에 쓰지 않는다.
+RUN chmod -R a+rwX packages/shared-types/dist
+
 EXPOSE 4000
 CMD ["node", "backend/src/index.ts"]

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -23,17 +23,16 @@ COPY --chown=node:node backend backend
 
 RUN npm run build --workspace=packages/shared-types
 
-# docker-compose.yml 이 `packages/shared-types/dist` 를 익명 볼륨으로 선언한다(호스트
-# bind mount 가 컨테이너 산출물을 가리지 않게). 그 볼륨은 지금 이 시점의 소유권(node,
-# uid 1000)을 그대로 물려받아 초기화되는데, 컨테이너를 다른 uid(`DEV_UID` — 리눅스에서
-# 호스트 소유자와 맞추는 값)로 띄우면 그 uid 가 못 쓴다 — 컨테이너가 뜰 때마다 이 build 를
-# 다시 돌리므로 매번 걸린다. 어떤 uid 로 뜨더라도 쓸 수 있게 미리 열어 둔다.
-#
-# `backend/node_modules`·`packages/shared-types/node_modules` 도 같은 이유로 익명
-# 볼륨이지만 여기서는 손대지 않는다 — npm 워크스페이스가 의존성을 루트 node_modules 로
-# 전부 호이스팅해서 이 경로 자체가 이미지 안에 존재하지 않고(런타임에 빈 디렉터리로
-# 새로 생긴다), 아무도 거기에 쓰지 않는다.
-RUN chmod -R a+rwX packages/shared-types/dist
+# 컨테이너는 root 로 시작해 진입점 스크립트가 익명 볼륨(node_modules · dist)의 소유권을
+# 목표 uid(`DEV_UID` — 리눅스에서 호스트 저장소 소유자와 맞추는 값)로 정리한 뒤,
+# su-exec 로 권한을 낮춰 실제 앱을 그 uid 로 실행한다. 그 이유와 build 시점 chmod 로는
+# 왜 부족한지는 docker-entrypoint-dev.sh 의 주석 참고. 앱 프로세스 자체는 여전히
+# non-root 로 도니 S7 은 그대로 지켜진다.
+USER root
+RUN apk add --no-cache su-exec
+COPY backend/docker-entrypoint-dev.sh /usr/local/bin/docker-entrypoint-dev.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint-dev.sh
+ENTRYPOINT ["docker-entrypoint-dev.sh"]
 
 EXPOSE 4000
 CMD ["node", "backend/src/index.ts"]

--- a/backend/docker-entrypoint-dev.sh
+++ b/backend/docker-entrypoint-dev.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+# 컨테이너 진입점 — 항상 root 로 시작해서 익명 볼륨의 소유권을 목표 uid 로 맞춘 뒤
+# su-exec 로 권한을 낮춰 실제 앱을 그 uid 로 실행한다.
+#
+# 왜 이게 필요한가: 이미지 빌드 시점에 chmod 를 해 두는 방식은 그 시점에 이미
+# 존재하는 디렉터리에만 적용된다. 익명 볼륨(node_modules · dist)은 컨테이너를
+# 재생성해도 내용이 유지되므로, 예전 uid(DEV_UID)로 뜬 적이 있는 볼륨을 다른 uid 로
+# 다시 띄우면 그 사이에 새로 생긴 하위 디렉터리(예: `dist` 를 매번 다시 빌드하며
+# 남는 산출물)는 옛 uid 소유로 남는다. 새 uid 는 그 파일의 소유자가 아니므로
+# chmod 조차 할 권한이 없다 — 그래서 root 로 시작해 그 제약 없이 소유권 자체를
+# 넘겨준다. 실제 앱 프로세스는 이 스크립트가 끝나면 non-root(기본 1000)로 넘어가므로
+# S7(non-root 실행)은 그대로 지켜진다.
+set -e
+
+TARGET_UID="${DEV_UID:-1000}"
+TARGET_GID="${DEV_GID:-1000}"
+
+# docker-compose.yml 이 backend 서비스에 선언한 익명 볼륨만 정리한다. bind mount 되는
+# 소스 디렉터리(backend/src 등)는 호스트 소유자를 그대로 물려받아야 하므로 대상이 아니다.
+chown -R "$TARGET_UID:$TARGET_GID" \
+  /app/backend/node_modules \
+  /app/packages/shared-types/node_modules \
+  /app/packages/shared-types/dist
+
+exec su-exec "$TARGET_UID:$TARGET_GID" "$@"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,7 +44,14 @@ services:
     # `DEV_UID=$(id -u) DEV_GID=$(id -g) docker compose up`. 안 맞을 일이 훨씬 많은
     # 리눅스에서만 신경 쓰면 되고, macOS·Windows 는 기본값(1000:1000)을 그대로 써도
     # 대개 문제가 없다. 값을 안 주면 이미지 빌드 시점의 uid 와 같아 기존 동작과 동일하다.
-    user: '${DEV_UID:-1000}:${DEV_GID:-1000}'
+    #
+    # 여기서 `user:` 를 직접 쓰지 않는다 — 그러면 컨테이너가 그 uid 로 곧장 시작돼,
+    # 이전에 다른 uid 로 뜬 적이 있는 익명 볼륨(node_modules·dist) 안의 파일을 그 uid
+    # 자신이 소유자가 아니라 chmod 조차 못 하게 된다(실측 확인: `DEV_UID` 를 바꿔 재기동하면
+    # EACCES 로 죽는다). 그래서 컨테이너는 항상 root 로 시작하고, 진입점 스크립트가 그
+    # 볼륨들의 소유권을 목표 uid 로 정리한 뒤 su-exec 로 권한을 낮춘다 — 이유는
+    # backend/docker-entrypoint-dev.sh 의 주석 참고.
+    #
     # 기동할 때마다 공유 타입을 먼저 빌드한다. `dist` 는 커밋 대상이 아니고 아래 익명 볼륨에
     # 담기므로, 이 단계가 없으면 타입 패키지를 고친 뒤 컨테이너가 옛 산출물을 그대로 쓴다.
     #
@@ -66,6 +73,10 @@ services:
       POSTGRES_DB: ${POSTGRES_DB:-ditter_dev}
       POSTGRES_USER: ${POSTGRES_USER:-ditter}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-ditter_local_dev_only}
+      # 진입점 스크립트(docker-entrypoint-dev.sh)가 이 값을 읽어 su-exec 로 권한을
+      # 낮춘다. 위 `user:` 관련 주석 참고.
+      DEV_UID: ${DEV_UID:-1000}
+      DEV_GID: ${DEV_GID:-1000}
     ports:
       - '127.0.0.1:4000:4000'
     # 첫 기동에는 위 command 의 공유 타입 빌드가 끝나야 서버가 뜬다. healthcheck 가 없으면
@@ -101,9 +112,10 @@ services:
       context: .
       dockerfile: frontend/Dockerfile
     # 리눅스에서 bind mount 소유자 uid 가 안 맞으면 쓰기가 막힌다 — backend 서비스의
-    # `user:` 주석 참고. 이 서비스가 특히 취약하다: Vite dev 서버가 기동할 때마다
+    # `DEV_UID` 주석 참고. 이 서비스가 특히 취약하다: Vite dev 서버가 기동할 때마다
     # `vite.config.ts` 옆에 설정 임시 파일을 쓰는데 그 디렉터리가 바로 이 bind mount 다.
-    user: '${DEV_UID:-1000}:${DEV_GID:-1000}'
+    # `user:` 를 안 쓰고 진입점 스크립트로 su-exec 하는 이유도 backend 와 동일하다.
+    #
     # 마지막 명령 앞의 `exec` 는 sh 를 그 프로세스로 치환해, 종료 신호가 sh 를 거치지 않고
     # Vite dev 서버까지 곧바로 닿게 한다 (backend 서비스와 동일한 이유).
     command: sh -c "npm run build --workspace=packages/shared-types && exec npm run dev --workspace=frontend"
@@ -115,6 +127,10 @@ services:
       # bind mount 를 통한 파일 변경은 호스트(macOS·Windows)에서 컨테이너 안으로 inotify
       # 이벤트가 전달되지 않는다. 폴링이 없으면 저장해도 화면이 갱신되지 않는다.
       VITE_DEV_POLL: 'true'
+      # 진입점 스크립트(docker-entrypoint-dev.sh)가 이 값을 읽어 su-exec 로 권한을
+      # 낮춘다. backend 서비스의 같은 이름 환경변수 주석 참고.
+      DEV_UID: ${DEV_UID:-1000}
+      DEV_GID: ${DEV_GID:-1000}
     ports:
       - '127.0.0.1:5173:5173'
     # 첫 기동에는 위 command 의 공유 타입 빌드가 끝나야 dev 서버가 뜬다. backend 서비스와

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,18 @@ services:
     build:
       context: .
       dockerfile: backend/Dockerfile
+    # 이미지 안의 `node` 계정은 uid:gid 1000:1000 으로 고정돼 있다(Dockerfile 의
+    # `USER node`). macOS 는 bind mount 를 다루는 파일시스템 계층(virtiofs 등)이 uid 를
+    # 투명하게 중재해 주는 경우가 많아 드러나지 않지만, **리눅스 네이티브 bind mount 는
+    # 커널이 실제 uid 로 권한을 그대로 검사한다.** 저장소 소유자가 1000이 아니면(우분투
+    # 등에서 흔함) 컨테이너가 bind mount 된 `./backend`·`./frontend`·`./packages` 에 쓰기
+    # 권한이 없어, Vite 가 설정 임시 파일을 못 써 프런트가 기동조차 못 할 수 있다.
+    #
+    # `DEV_UID`·`DEV_GID` 를 호스트 uid/gid(`id -u`·`id -g`)로 맞추면 해결된다 — 예:
+    # `DEV_UID=$(id -u) DEV_GID=$(id -g) docker compose up`. 안 맞을 일이 훨씬 많은
+    # 리눅스에서만 신경 쓰면 되고, macOS·Windows 는 기본값(1000:1000)을 그대로 써도
+    # 대개 문제가 없다. 값을 안 주면 이미지 빌드 시점의 uid 와 같아 기존 동작과 동일하다.
+    user: '${DEV_UID:-1000}:${DEV_GID:-1000}'
     # 기동할 때마다 공유 타입을 먼저 빌드한다. `dist` 는 커밋 대상이 아니고 아래 익명 볼륨에
     # 담기므로, 이 단계가 없으면 타입 패키지를 고친 뒤 컨테이너가 옛 산출물을 그대로 쓴다.
     #
@@ -88,6 +100,10 @@ services:
     build:
       context: .
       dockerfile: frontend/Dockerfile
+    # 리눅스에서 bind mount 소유자 uid 가 안 맞으면 쓰기가 막힌다 — backend 서비스의
+    # `user:` 주석 참고. 이 서비스가 특히 취약하다: Vite dev 서버가 기동할 때마다
+    # `vite.config.ts` 옆에 설정 임시 파일을 쓰는데 그 디렉터리가 바로 이 bind mount 다.
+    user: '${DEV_UID:-1000}:${DEV_GID:-1000}'
     # 마지막 명령 앞의 `exec` 는 sh 를 그 프로세스로 치환해, 종료 신호가 sh 를 거치지 않고
     # Vite dev 서버까지 곧바로 닿게 한다 (backend 서비스와 동일한 이유).
     command: sh -c "npm run build --workspace=packages/shared-types && exec npm run dev --workspace=frontend"

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -26,21 +26,16 @@ COPY --chown=node:node frontend frontend
 
 RUN npm run build --workspace=packages/shared-types
 
-# docker-compose.yml 이 이 경로들을 익명 볼륨으로 선언한다(호스트 bind mount 가 컨테이너
-# 산출물을 가리지 않게). 그 볼륨은 지금 이 시점의 소유권(node, uid 1000)을 그대로 물려받아
-# 초기화되는데, 컨테이너를 다른 uid(`DEV_UID` — 리눅스에서 호스트 소유자와 맞추는 값)로
-# 띄우면 그 uid 가 못 쓴다. `dist` 는 컨테이너가 뜰 때마다 이 build 를 다시 돌리므로 매번
-# 걸리고, `frontend/node_modules` 는 npm 워크스페이스 호이스팅 때문에 이미지에 원래
-# 존재하지 않는데 Vite 가 의존성 사전 번들링 캐시(`node_modules/.vite`)를 거기 쓰려고
-# 시도한다 — 실측: `mkdir -p` 없이 두면 `EACCES: permission denied, mkdir
-# '.../node_modules/.vite/deps_temp_...'` 로 매 리로드마다 에러가 난다(화면 자체는
-# 캐시 없이도 뜨지만 계속 에러가 쌓인다). 어떤 uid 로 뜨더라도 쓸 수 있게 미리 만들어 연다.
-#
-# `packages/shared-types/node_modules` 는 같은 익명 볼륨 목록에 있지만 손대지 않는다 —
-# 마찬가지로 이미지에 존재하지 않는 경로이고, node_modules 하위이니 같은 이유로 안전할
-# 것 같지만 실제로 거기에 쓰는 동작은 확인되지 않았다.
-RUN mkdir -p frontend/node_modules && \
-    chmod -R a+rwX packages/shared-types/dist frontend/node_modules
+# 컨테이너는 root 로 시작해 진입점 스크립트가 익명 볼륨(node_modules · dist)의 소유권을
+# 목표 uid(`DEV_UID` — 리눅스에서 호스트 저장소 소유자와 맞추는 값)로 정리한 뒤,
+# su-exec 로 권한을 낮춰 실제 앱을 그 uid 로 실행한다. 그 이유와 build 시점 chmod 로는
+# 왜 부족한지는 docker-entrypoint-dev.sh 의 주석 참고. 앱 프로세스 자체는 여전히
+# non-root 로 도니 S7 은 그대로 지켜진다.
+USER root
+RUN apk add --no-cache su-exec
+COPY frontend/docker-entrypoint-dev.sh /usr/local/bin/docker-entrypoint-dev.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint-dev.sh
+ENTRYPOINT ["docker-entrypoint-dev.sh"]
 
 EXPOSE 5173
 CMD ["npm", "run", "dev", "--workspace=frontend"]

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -26,5 +26,21 @@ COPY --chown=node:node frontend frontend
 
 RUN npm run build --workspace=packages/shared-types
 
+# docker-compose.yml 이 이 경로들을 익명 볼륨으로 선언한다(호스트 bind mount 가 컨테이너
+# 산출물을 가리지 않게). 그 볼륨은 지금 이 시점의 소유권(node, uid 1000)을 그대로 물려받아
+# 초기화되는데, 컨테이너를 다른 uid(`DEV_UID` — 리눅스에서 호스트 소유자와 맞추는 값)로
+# 띄우면 그 uid 가 못 쓴다. `dist` 는 컨테이너가 뜰 때마다 이 build 를 다시 돌리므로 매번
+# 걸리고, `frontend/node_modules` 는 npm 워크스페이스 호이스팅 때문에 이미지에 원래
+# 존재하지 않는데 Vite 가 의존성 사전 번들링 캐시(`node_modules/.vite`)를 거기 쓰려고
+# 시도한다 — 실측: `mkdir -p` 없이 두면 `EACCES: permission denied, mkdir
+# '.../node_modules/.vite/deps_temp_...'` 로 매 리로드마다 에러가 난다(화면 자체는
+# 캐시 없이도 뜨지만 계속 에러가 쌓인다). 어떤 uid 로 뜨더라도 쓸 수 있게 미리 만들어 연다.
+#
+# `packages/shared-types/node_modules` 는 같은 익명 볼륨 목록에 있지만 손대지 않는다 —
+# 마찬가지로 이미지에 존재하지 않는 경로이고, node_modules 하위이니 같은 이유로 안전할
+# 것 같지만 실제로 거기에 쓰는 동작은 확인되지 않았다.
+RUN mkdir -p frontend/node_modules && \
+    chmod -R a+rwX packages/shared-types/dist frontend/node_modules
+
 EXPOSE 5173
 CMD ["npm", "run", "dev", "--workspace=frontend"]

--- a/frontend/docker-entrypoint-dev.sh
+++ b/frontend/docker-entrypoint-dev.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+# 컨테이너 진입점 — 항상 root 로 시작해서 익명 볼륨의 소유권을 목표 uid 로 맞춘 뒤
+# su-exec 로 권한을 낮춰 실제 앱을 그 uid 로 실행한다.
+#
+# 왜 이게 필요한가: 이미지 빌드 시점에 chmod 를 해 두는 방식은 그 시점에 이미
+# 존재하는 디렉터리에만 적용된다. 익명 볼륨(node_modules · dist)은 컨테이너를
+# 재생성해도 내용이 유지되므로, 예전 uid(DEV_UID)로 뜬 적이 있는 볼륨을 다른 uid 로
+# 다시 띄우면 그 사이에 새로 생긴 하위 디렉터리는 옛 uid 소유로 남는다. 특히 Vite 는
+# 기동할 때마다 `node_modules/.vite-temp` 에 설정 번들 임시 파일을 쓰는데, 그
+# 디렉터리 자체가 이전 uid 로 이미 만들어져 있으면 새 uid 는 그 파일의 소유자가
+# 아니므로 chmod 조차 할 권한이 없다 — 그래서 root 로 시작해 그 제약 없이 소유권
+# 자체를 넘겨준다. 실제 앱 프로세스는 이 스크립트가 끝나면 non-root(기본 1000)로
+# 넘어가므로 S7(non-root 실행)은 그대로 지켜진다.
+set -e
+
+TARGET_UID="${DEV_UID:-1000}"
+TARGET_GID="${DEV_GID:-1000}"
+
+# docker-compose.yml 이 frontend 서비스에 선언한 익명 볼륨만 정리한다. bind mount 되는
+# 소스 디렉터리(frontend/src 등)는 호스트 소유자를 그대로 물려받아야 하므로 대상이 아니다.
+chown -R "$TARGET_UID:$TARGET_GID" \
+  /app/frontend/node_modules \
+  /app/packages/shared-types/node_modules \
+  /app/packages/shared-types/dist
+
+exec su-exec "$TARGET_UID:$TARGET_GID" "$@"


### PR DESCRIPTION
## 변경 요약

[#20](https://github.com/SurvivorsStudio/ditter/pull/20)에서 이월했던 마지막 후속 항목 3번 — 리눅스 호스트에서 컨테이너 uid와 저장소 소유자가 다를 때 bind mount 쓰기가 막혀 프런트가 기동하지 못할 수 있는 문제를 고친다.

- **원래 문제**: 컨테이너는 이미지에 고정된 uid:gid 1000:1000(`node` 계정)으로 도는데, bind mount 되는 소스 디렉터리는 호스트 소유자를 그대로 물려받는다. macOS는 bind mount를 다루는 파일시스템 계층이 uid를 투명하게 중재해 대부분 안 드러나지만, 리눅스 네이티브 bind mount는 커널이 실제 uid로 권한을 그대로 검사한다.
- `docker-compose.yml`의 backend·frontend 서비스가 `DEV_UID`/`DEV_GID` 환경변수(기본값 1000:1000 — 기존 동작과 동일)를 읽는다. 리눅스에서 `DEV_UID=$(id -u) DEV_GID=$(id -g) docker compose up`으로 호스트 uid에 맞추면 해결된다.
- 컨테이너는 항상 root로 시작해, 진입점 스크립트(`backend/docker-entrypoint-dev.sh`, `frontend/docker-entrypoint-dev.sh` — 신규)가 익명 볼륨(`node_modules`·`dist`)의 소유권을 목표 uid로 정리한 뒤 `su-exec`로 권한을 낮춰 실제 앱을 그 uid로 실행한다. root는 그 몇 줄 `chown` 동안만 쓰이고 실제 앱 프로세스는 여전히 non-root다(S7 유지).

## 테스트 방법

- `docker compose config -q`, `npm run format:check`, `npm run lint`, 두 entrypoint 스크립트 `sh -n` 문법 검사 — 전부 통과.
- **기본값 회귀**: `docker compose down -v` → `up --build --wait`로 완전 재빌드 → 세 서비스 healthy, `/proc/1/status`로 실제 앱 프로세스가 uid 1000임을 확인, 백엔드·프런트 hot reload 정상, LAN 포트 차단 유지.
- **대체 uid로 첫 기동**: `DEV_UID=$(id -u) DEV_GID=$(id -g)`(macOS 호스트 uid 501)로 fresh 기동 → healthy, `/proc/1/status`로 PID 1이 501임을 확인, hot reload 정상.
- **전환 시나리오(이 PR의 핵심 검증)**: 기본값으로 기동해 익명 볼륨이 uid 1000으로 만들어지게 한 뒤, `down` 없이 `DEV_UID`를 바꿔 `up`을 다시 실행(Recreate — 익명 볼륨 유지). 첫 시도(build 시점 chmod만 있던 버전)에서는 frontend가 `EACCES: .../node_modules/.vite-temp/vite.config.ts.timestamp-....mjs`로 exit(1)했고, entrypoint 구조로 재작성한 뒤에는 동일 시나리오에서 세 서비스 모두 healthy로 확인했다.

## 코드리뷰

**이번 review 요약**: 2사이클(고위험 경로) 진행 — cycle 1에서 확정 수정 1건, cycle 2는 순수 재확인(CLEAN). 이월 0건.

cycle 1에서 실제로 첫 수정안(`user:` 오버라이드 + build 시점 chmod)에 있던 구조적 결함이 잡혔다: 익명 볼륨은 컨테이너 재생성 간 유지되는데, build 시점 chmod는 그 시점에 존재하는 파일에만 적용되고 Vite가 런타임에 새로 만드는 `.vite-temp` 캐시 디렉터리는 대상이 아니었다. 게다가 컨테이너가 이미 비-root 대상 uid로 직접 시작하면(`user:` 오버라이드), 이전 uid가 소유한 파일에 대해 새 uid는 chmod조차 할 권한이 없어(EPERM) 런타임에 뒤늦게 고치는 것도 불가능했다. 실제 컨테이너에서 정확한 실패를 재현한 뒤(2회 반복 확인), root로 시작해 entrypoint가 매 기동마다 익명 볼륨 소유권을 정리하고 `su-exec`로 권한을 낮추는 구조로 재작성했다. cycle 1과 cycle 2 모두 같은 전환 시나리오를 독립적으로 재현·재검증했다.

부가 관찰(별도 조치 없이 스킵): `apk add --no-cache su-exec`가 버전 핀 없이 설치되지만, S2·S5(npm 의존성 대상)의 적용 범위 밖이고 베이스 이미지 자체도 태그만 고정하는 기존 관용 수준과 동일하다고 판단했다. 이미지의 최종 `USER`가 `root`로 남아 `docker compose exec service sh` 같은 별도 진입은 기본적으로 root로 열리지만, entrypoint를 거치는 실제 앱 프로세스는 항상 `su-exec`로 낮아지므로(postgres·mysql 공식 이미지도 쓰는 잘 알려진 패턴) 별도 조치하지 않았다.
