### PR TITLE
feat: AI 쿼리 튜닝을 실행 계획 기반으로 강화하고 성능 비교를 추가한다

### DIFF
--- a/apps/api/src/eai_api/routers/ai.py
+++ b/apps/api/src/eai_api/routers/ai.py
@@ -35,6 +35,7 @@ def chat(
         db_connection_id=payload.db_connection_id,
         sql=payload.sql,
         error=payload.error,
+        explain=payload.explain,
         include_samples=payload.include_samples,
     )
     return AiChatResponse(

--- a/apps/api/src/eai_api/schemas/ai.py
+++ b/apps/api/src/eai_api/schemas/ai.py
@@ -24,6 +24,8 @@ class AiChatRequest(BaseModel):
     sql: str | None = None
     #: 방금 실패한 오류 메시지 (선택)
     error: str | None = None
+    #: 실제 실행 계획(EXPLAIN [ANALYZE]) 텍스트 — 계획 기반 튜닝(intent=sql.tune)에 쓴다.
+    explain: str | None = None
     #: 언급된 테이블의 예시 행을 프롬프트에 넣어 값→컬럼 매핑 정확도를 높인다.
     #: 실제 데이터가 AI 프로바이더로 전송되므로 기본은 꺼짐 — 프론트가 토글로 켠다.
     include_samples: bool = False

--- a/apps/api/src/eai_api/services/ai_service.py
+++ b/apps/api/src/eai_api/services/ai_service.py
@@ -73,7 +73,7 @@ _BASE_RULES = (
 )
 
 
-def _prompt_generate(dialect: str | None, schema: str | None, sql: str | None, error: str | None) -> str:
+def _prompt_generate(dialect: str | None, schema: str | None, sql: str | None, error: str | None, explain: str | None = None) -> str:
     d = dialect or "표준 SQL"
     parts = [f"너는 {d} 전용 SQL 어시스턴트다. 사용자의 요청을 SQL 로 만들어 준다.", _BASE_RULES]
     if schema:
@@ -81,7 +81,13 @@ def _prompt_generate(dialect: str | None, schema: str | None, sql: str | None, e
     return "\n".join(parts)
 
 
-def _prompt_tune(dialect: str | None, schema: str | None, sql: str | None, error: str | None) -> str:
+def _prompt_tune(
+    dialect: str | None,
+    schema: str | None,
+    sql: str | None,
+    error: str | None,
+    explain: str | None = None,
+) -> str:
     d = dialect or "표준 SQL"
     parts = [
         f"너는 {d} 성능 튜닝 전문가다. 주어진 쿼리를 **결과가 동등함을 보장하며** 개선한다.",
@@ -89,6 +95,16 @@ def _prompt_tune(dialect: str | None, schema: str | None, sql: str | None, error
         "- 인덱스·조인 순서·불필요한 스캔을 줄이는 방향으로 고쳐라.\n"
         "- 무엇을 왜 바꿨는지, 어떤 인덱스가 있으면 더 좋은지 짚어라.",
     ]
+    if explain:
+        parts.append(
+            "\n아래는 이 쿼리의 **실제 실행 계획**이다. 추측하지 말고 계획에서 드러난 병목을 "
+            "근거로 튜닝하라:\n"
+            "- 풀스캔(Seq Scan·Table scan)·인덱스 미사용(컬럼을 함수로 감싸 sargable 하지 않음, "
+            "  암시적 형변환, 선두 와일드카드 LIKE)·과도한 정렬/임시테이블을 우선 짚어라.\n"
+            "- 인덱스가 있으면 좋을 자리는 `CREATE INDEX` 문으로 제안하되 **실행하지 말고 제안만** 한다.\n"
+            "- 계획이 이미 최적이면 억지로 바꾸지 말고 그렇다고 말하라.\n"
+            f"\n실행 계획:\n{explain}"
+        )
     if schema:
         parts.append(f"\n대상 스키마:\n{schema}")
     if sql:
@@ -98,7 +114,7 @@ def _prompt_tune(dialect: str | None, schema: str | None, sql: str | None, error
     return "\n".join(parts)
 
 
-def _prompt_interpret(dialect: str | None, schema: str | None, sql: str | None, error: str | None) -> str:
+def _prompt_interpret(dialect: str | None, schema: str | None, sql: str | None, error: str | None, explain: str | None = None) -> str:
     """실행 결과 해석 — SQL 을 새로 만들지 않고, 사용자가 받은 결과를 한국어로 풀어 준다."""
     d = dialect or "SQL"
     parts = [
@@ -120,7 +136,7 @@ def _prompt_interpret(dialect: str | None, schema: str | None, sql: str | None, 
     return "\n".join(parts)
 
 
-def _prompt_chart(dialect: str | None, schema: str | None, sql: str | None, error: str | None) -> str:
+def _prompt_chart(dialect: str | None, schema: str | None, sql: str | None, error: str | None, explain: str | None = None) -> str:
     """차트 생성 — 실행 결과를 ```chart JSON 블록 하나로 시각화한다."""
     parts = [
         "너는 데이터 시각화 어시스턴트다. 사용자가 실행한 SQL 과 결과 표를 받아, 그 결과를 "
@@ -141,7 +157,7 @@ def _prompt_chart(dialect: str | None, schema: str | None, sql: str | None, erro
     return "\n".join(parts)
 
 
-def _prompt_report(dialect: str | None, schema: str | None, sql: str | None, error: str | None) -> str:
+def _prompt_report(dialect: str | None, schema: str | None, sql: str | None, error: str | None, explain: str | None = None) -> str:
     """보고서 작성 — 실행 결과를 구조화된 한국어 마크다운 보고서로 정리한다."""
     parts = [
         "너는 데이터 분석 보고서 작성자다. 사용자가 실행한 SQL 과 결과 표를 받아, 읽기 좋은 "
@@ -161,7 +177,7 @@ def _prompt_report(dialect: str | None, schema: str | None, sql: str | None, err
     return "\n".join(parts)
 
 
-def _prompt_fix(dialect: str | None, schema: str | None, sql: str | None, error: str | None) -> str:
+def _prompt_fix(dialect: str | None, schema: str | None, sql: str | None, error: str | None, explain: str | None = None) -> str:
     """오류 수정 — 실행에 실패한 쿼리와 오류 메시지를 보고, 의미는 유지한 채 오류만 고친다."""
     d = dialect or "표준 SQL"
     parts = [
@@ -185,7 +201,7 @@ def _prompt_fix(dialect: str | None, schema: str | None, sql: str | None, error:
 
 
 #: intent → 시스템 프롬프트 빌더. 새 의도는 여기 한 줄이면 된다.
-_INTENTS: dict[str, Callable[[str | None, str | None, str | None, str | None], str]] = {
+_INTENTS: dict[str, Callable[[str | None, str | None, str | None, str | None, str | None], str]] = {
     "sql.generate": _prompt_generate,
     "sql.tune": _prompt_tune,
     "sql.interpret": _prompt_interpret,
@@ -211,6 +227,7 @@ def chat(
     db_connection_id: str | None = None,
     sql: str | None = None,
     error: str | None = None,
+    explain: str | None = None,
     include_samples: bool = False,
 ) -> AiChatResult:
     if intent not in _INTENTS:
@@ -231,7 +248,7 @@ def chat(
     dialect, schema_text, schema_note = _schema_context(
         session, db_connection_id, convo_text, include_samples=include_samples
     )
-    system = _INTENTS[intent](dialect, schema_text, sql, error)
+    system = _INTENTS[intent](dialect, schema_text, sql, error, explain)
 
     result = connector.generate(list(messages), system=system)  # ConnectorError 는 전역 핸들러가 처리
     return AiChatResult(

--- a/apps/api/tests/test_ai_service.py
+++ b/apps/api/tests/test_ai_service.py
@@ -216,6 +216,23 @@ def test_chart_intent_outputs_chart_block(monkeypatch) -> None:
     assert "labels" in conn.seen["system"]  # 차트 형식 안내가 시스템 프롬프트에 있다
 
 
+def test_tune_intent_includes_explain_plan(monkeypatch) -> None:
+    # 계획 기반 튜닝 — EXPLAIN 텍스트가 시스템 프롬프트에 실려 근거로 쓰인다.
+    conn = _AiConnector(text="```sql\nSELECT ...\n```\n날짜 범위로 바꿔 인덱스를 씁니다.")
+    _patch(monkeypatch, ai_conn=_Conn("gemini"), connector=conn)
+    svc.chat(
+        None,
+        ai_connection_id="ai",
+        messages=[{"role": "user", "content": "튜닝"}],
+        intent="sql.tune",
+        sql="SELECT * FROM orders WHERE YEAR(ordered_at)=2024",
+        explain="Filter: (year(o.ordered_at) = 2024)  cost=320",
+    )  # type: ignore[arg-type]
+    assert "실행 계획" in conn.seen["system"]
+    assert "cost=320" in conn.seen["system"]  # 실제 계획을 문맥에 실었다
+    assert "CREATE INDEX" in conn.seen["system"]  # 인덱스 제안 규칙
+
+
 def test_fix_intent_includes_query_and_error(monkeypatch) -> None:
     conn = _AiConnector(text="```sql\nSELECT * FROM shop.customers\n```\n3번째 줄의 '111' 을 지웠습니다.")
     _patch(monkeypatch, ai_conn=_Conn("gemini"), connector=conn)

--- a/apps/web/src/api/hooks.ts
+++ b/apps/web/src/api/hooks.ts
@@ -287,6 +287,7 @@ export function useAiChat() {
       db_connection_id?: string | null
       sql?: string | null
       error?: string | null
+      explain?: string | null
       include_samples?: boolean
     }) => api.parsed(aiChatOutSchema, '/ai/chat', { method: 'POST', body }),
   })

--- a/apps/web/src/canvas/ExplainModal.tsx
+++ b/apps/web/src/canvas/ExplainModal.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { Icon } from '../components/icons'
+import { AiFixPanel } from '../components/AiFixPanel'
 
 export type ExplainTarget = { plan: string; analyzed: boolean; sql: string }
 
@@ -20,9 +21,30 @@ function summarize(plan: string, analyzed: boolean): { label: string; value: str
   return out
 }
 
-/** 쿼리 실행 계획 모달 — 텍스트 계획 + 요약. */
-export function ExplainModal({ target, onClose }: { target: ExplainTarget; onClose: () => void }) {
+/** 쿼리 실행 계획 모달 — 텍스트 계획 + 요약 + (선택) 계획 기반 AI 튜닝. */
+export function ExplainModal({
+  target,
+  onClose,
+  dbConnId,
+  onApply,
+  onAiEscalate,
+}: {
+  target: ExplainTarget
+  onClose: () => void
+  /** 스키마 문맥용 대상 DB — 있으면 「AI 튜닝」을 띄운다. */
+  dbConnId?: string
+  /** 튜닝된 쿼리를 편집기에 적용. */
+  onApply?: (sql: string) => void
+  onAiEscalate?: (payload: {
+    sql: string
+    error?: string
+    explain?: string
+    assistant: string
+    dbConnId?: string
+  }) => void
+}) {
   const [copied, setCopied] = useState(false)
+  const [tuning, setTuning] = useState(false)
   const summary = useMemo(() => summarize(target.plan, target.analyzed), [target])
 
   const copyPlan = async () => {
@@ -60,11 +82,40 @@ export function ExplainModal({ target, onClose }: { target: ExplainTarget; onClo
           )}
           <div className="obj-sec-hd">
             <h4>실행 계획</h4>
-            <button className="btn sm" onClick={copyPlan}>
-              <Icon.copy />
-              {copied ? '복사됨' : '복사'}
-            </button>
+            <div className="obj-sec-actions">
+              {onApply && (
+                <button
+                  className={`btn sm ${tuning ? '' : 'primary'}`}
+                  onClick={() => setTuning((v) => !v)}
+                  title="이 계획을 근거로 AI 가 쿼리를 튜닝합니다"
+                >
+                  <Icon.bolt /> {tuning ? 'AI 튜닝 닫기' : 'AI 튜닝'}
+                </button>
+              )}
+              <button className="btn sm" onClick={copyPlan}>
+                <Icon.copy />
+                {copied ? '복사됨' : '복사'}
+              </button>
+            </div>
           </div>
+          {tuning && onApply && (
+            <AiFixPanel
+              mode="tune"
+              sql={target.sql}
+              explain={target.plan}
+              explainAnalyzed={target.analyzed}
+              dbConnId={dbConnId}
+              onApply={(sql) => {
+                onApply(sql)
+                onClose()
+              }}
+              onEscalate={(p) => {
+                onAiEscalate?.({ ...p, dbConnId })
+                onClose()
+              }}
+              onClose={() => setTuning(false)}
+            />
+          )}
           <pre className="explain-plan">{target.plan}</pre>
           {!target.analyzed && (
             <div className="explain-note">

--- a/apps/web/src/canvas/SqlEditor.tsx
+++ b/apps/web/src/canvas/SqlEditor.tsx
@@ -860,7 +860,7 @@ export function SqlWorkbench({
    *  실수 방지용 장치이고, 진짜 가드는 연결의 허용 명령(서버)이다. */
   muted?: SqlStatement[]
   /** 「AI 탭에서 이어가기」 — 오류 수정 패널의 대화 승격을 페이지가 처리한다. */
-  onAiEscalate?: (payload: { sql: string; error: string; assistant: string; dbConnId?: string }) => void
+  onAiEscalate?: (payload: { sql: string; error?: string; explain?: string; assistant: string; dbConnId?: string }) => void
 }) {
   const cmRef = useRef<ReactCodeMirrorRef>(null)
   const gridRef = useRef<HTMLDivElement>(null)
@@ -2111,7 +2111,13 @@ export function SqlWorkbench({
           document.body,
         )}
       {explainResult && (
-        <ExplainModal target={explainResult} onClose={() => setExplainResult(null)} />
+        <ExplainModal
+          target={explainResult}
+          onClose={() => setExplainResult(null)}
+          dbConnId={connectionId}
+          onApply={(fixed) => onChange(fixed)}
+          onAiEscalate={onAiEscalate}
+        />
       )}
       {favSave &&
         createPortal(

--- a/apps/web/src/components/AiFixPanel.tsx
+++ b/apps/web/src/components/AiFixPanel.tsx
@@ -1,33 +1,75 @@
-/** 오류 자리에 뜨는 AI 수정 패널 — 편집기·노트북 공용.
+/** 쿼리 옆에 뜨는 AI 액션 패널 — 오류 수정(fix)·성능 튜닝(tune) 공용, 편집기·노트북 겸용.
  *
- *  실패한 쿼리와 오류 메시지를 AI(sql.fix 의도)에 보내 "진단 한 줄 + 고친 SQL"을 받는다.
- *  고친 SQL 은 바로 실행하지 않고 **편집기에 적용**(되돌리기 가능)하거나, 부족하면
+ *  fix: 실패한 쿼리와 오류 메시지를 sql.fix 로 보내 "진단 + 고친 SQL".
+ *  tune: 쿼리와 실제 EXPLAIN 계획을 sql.tune 으로 보내 "병목 진단 + 튜닝된 SQL(+인덱스 제안)".
+ *  결과 SQL 은 바로 실행하지 않고 **편집기에 적용**(되돌리기 가능)하거나, 부족하면
  *  **AI 탭에서 이어가기**로 대화로 승격한다. 응답은 공용 Markdown 렌더러로 그린다.
  */
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { Icon } from './icons'
 import { Markdown } from './Markdown'
 import { MiniSelect } from '../canvas/AiChatPane'
-import { useAiChat, useConnections } from '../api/hooks'
+import { useAiChat, useConnections, useExplain } from '../api/hooks'
 import { specFor } from '../api/connectorFields'
 import type { SelectOption } from './SearchSelect'
 
+/** EXPLAIN [ANALYZE] 텍스트에서 총 실행 시간(ms)과 예상 비용을 뽑는다 (MySQL·PostgreSQL). */
+function parsePerf(plan: string): { timeMs: number | null; cost: number | null } {
+  const exec = /Execution Time:\s*([\d.]+)\s*ms/i.exec(plan) // PostgreSQL ANALYZE
+  const rootActual = /actual time=[\d.]+\.\.([\d.]+)/.exec(plan) // MySQL ANALYZE 루트 노드
+  const costM = /cost=[\d.]+\.\.([\d.]+)/.exec(plan) || /cost=([\d.]+)/.exec(plan)
+  return {
+    timeMs: exec ? Number(exec[1]) : rootActual ? Number(rootActual[1]) : null,
+    cost: costM ? Number(costM[1]) : null,
+  }
+}
+
+const fmtMs = (n: number) => (n >= 1000 ? `${(n / 1000).toFixed(2)} s` : `${n.toFixed(0)} ms`)
+
+const MODE_CFG = {
+  fix: {
+    intent: 'sql.fix' as const,
+    title: 'AI 수정',
+    loading: '오류를 분석하는 중…',
+    userMsg: '이 쿼리의 오류를 고쳐줘.',
+    apply: '편집기에 적용',
+  },
+  tune: {
+    intent: 'sql.tune' as const,
+    title: 'AI 튜닝',
+    loading: '실행 계획을 분석하는 중…',
+    userMsg: '실행 계획을 근거로 이 쿼리를 튜닝해줘.',
+    apply: '튜닝된 쿼리 적용',
+  },
+}
+
 export function AiFixPanel({
+  mode = 'fix',
   sql,
   error,
+  explain,
+  explainAnalyzed,
   dbConnId,
   onApply,
   onEscalate,
   onClose,
 }: {
+  /** 'fix' = 오류 수정(기본), 'tune' = 계획 기반 성능 튜닝. */
+  mode?: 'fix' | 'tune'
   sql: string
-  error: string
+  /** fix 모드의 오류 메시지. */
+  error?: string
+  /** tune 모드의 실제 실행 계획(EXPLAIN) 텍스트. */
+  explain?: string
+  /** AS-IS 계획이 EXPLAIN ANALYZE(실제 시간 포함)로 뽑혔는지 — 성능 비교의 전제. */
+  explainAnalyzed?: boolean
   /** 스키마 문맥용 대상 DB (SQL 모드에서만). */
   dbConnId?: string
   onApply: (sql: string) => void
-  onEscalate: (payload: { sql: string; error: string; assistant: string }) => void
+  onEscalate: (payload: { sql: string; error?: string; explain?: string; assistant: string }) => void
   onClose: () => void
 }) {
+  const cfg = MODE_CFG[mode]
   const { data: conns = [] } = useConnections()
   const aiConns = useMemo(() => conns.filter((c) => specFor(c.type).category === 'ai'), [conns])
   const [aiConnId, setAiConnId] = useState('')
@@ -44,18 +86,43 @@ export function AiFixPanel({
   const [result, setResult] = useState<{ text: string; sql: string | null } | null>(null)
   const [failed, setFailed] = useState<string | null>(null)
 
-  const runFix = (connId: string) => {
+  // 성능 비교(AS-IS/TO-BE) — 튜닝 결과 쿼리를 EXPLAIN ANALYZE 로 재보고 원본 계획과 견준다.
+  const explainMut = useExplain()
+  const [perf, setPerf] = useState<{
+    asis: ReturnType<typeof parsePerf>
+    tobe: ReturnType<typeof parsePerf>
+  } | null>(null)
+  const [perfErr, setPerfErr] = useState<string | null>(null)
+  const compare = (tunedSql: string) => {
+    if (!dbConnId) return
+    setPerf(null)
+    setPerfErr(null)
+    explainMut.mutate(
+      { id: dbConnId, query: tunedSql, analyze: true },
+      {
+        onSuccess: (r) =>
+          setPerf({ asis: parsePerf(explain ?? ''), tobe: parsePerf(r.plan) }),
+        onError: (e) =>
+          setPerfErr(e instanceof Error ? e.message : '튜닝 쿼리 성능 분석에 실패했습니다.'),
+      },
+    )
+  }
+
+  const run = (connId: string) => {
     if (!connId) return
     setResult(null)
     setFailed(null)
+    setPerf(null)
+    setPerfErr(null)
     chat.mutate(
       {
         ai_connection_id: connId,
-        messages: [{ role: 'user', content: '이 쿼리의 오류를 고쳐줘.' }],
-        intent: 'sql.fix',
+        messages: [{ role: 'user', content: cfg.userMsg }],
+        intent: cfg.intent,
         db_connection_id: dbConnId ?? null,
         sql,
-        error,
+        error: error ?? null,
+        explain: explain ?? null,
       },
       {
         onSuccess: (out) => setResult({ text: out.message.content, sql: out.sql }),
@@ -64,12 +131,12 @@ export function AiFixPanel({
     )
   }
 
-  // 모델이 정해지면 한 번 자동 실행한다(오류 자리에서 바로 진단을 보여주려는 것).
+  // 모델이 정해지면 한 번 자동 실행한다(오류·계획 자리에서 바로 결과를 보여주려는 것).
   const started = useRef(false)
   useEffect(() => {
     if (aiConnId && !started.current) {
       started.current = true
-      runFix(aiConnId)
+      run(aiConnId)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [aiConnId])
@@ -79,7 +146,7 @@ export function AiFixPanel({
       <div className="ai-fix">
         <div className="ai-fix-head">
           <Icon.bolt />
-          <span>AI 수정</span>
+          <span>{cfg.title}</span>
           <button className="ai-fix-x" onClick={onClose} title="닫기">×</button>
         </div>
         <div className="ai-fix-body ai-fix-empty">
@@ -93,14 +160,14 @@ export function AiFixPanel({
     <div className="ai-fix">
       <div className="ai-fix-head">
         <Icon.bolt />
-        <span>AI 수정</span>
+        <span>{cfg.title}</span>
         <div className="ai-fix-head-right">
           <MiniSelect
             value={aiConnId}
             options={aiOptions}
             onChange={(v) => {
               setAiConnId(v)
-              runFix(v)
+              run(v)
             }}
             placeholder="AI 모델"
             align="right"
@@ -114,7 +181,7 @@ export function AiFixPanel({
         {chat.isPending ? (
           <div className="ai-fix-loading">
             <span className="ai-progress-spin" />
-            오류를 분석하는 중…
+            {cfg.loading}
           </div>
         ) : failed ? (
           <div className="ai-fix-error">{failed}</div>
@@ -123,24 +190,87 @@ export function AiFixPanel({
             <Markdown text={result.text} />
             <div className="ai-fix-actions">
               {result.sql && (
-                <button className="btn sm primary" onClick={() => onApply(result.sql!)} title="고친 쿼리를 편집기에 넣습니다(되돌리기 가능)">
-                  <Icon.check /> 편집기에 적용
+                <button className="btn sm primary" onClick={() => onApply(result.sql!)} title="결과 쿼리를 편집기에 넣습니다(되돌리기 가능)">
+                  <Icon.check /> {cfg.apply}
                 </button>
               )}
               <button
                 className="btn sm"
-                onClick={() => onEscalate({ sql, error, assistant: result.text })}
+                onClick={() => onEscalate({ sql, error, explain, assistant: result.text })}
                 title="AI 어시스턴트 탭에서 대화로 이어갑니다"
               >
                 <Icon.bolt /> AI 탭에서 이어가기
               </button>
-              <button className="btn sm" onClick={() => runFix(aiConnId)} title="다시 분석">
+              {mode === 'tune' && dbConnId && result.sql && (
+                <button
+                  className="btn sm"
+                  onClick={() => compare(result.sql!)}
+                  disabled={explainMut.isPending}
+                  title="튜닝된 쿼리를 EXPLAIN ANALYZE 로 재보고 원본과 비교합니다"
+                >
+                  <Icon.chart /> {explainMut.isPending ? '분석 중…' : '성능 비교'}
+                </button>
+              )}
+              <button className="btn sm" onClick={() => run(aiConnId)} title="다시 분석">
                 <Icon.refresh /> 다시
               </button>
             </div>
+            {perfErr && <div className="ai-fix-error" style={{ marginTop: 8 }}>{perfErr}</div>}
+            {perf && <PerfCompare asis={perf.asis} tobe={perf.tobe} analyzed={explainAnalyzed} />}
           </>
         ) : null}
       </div>
+    </div>
+  )
+}
+
+/** AS-IS(원본) / TO-BE(튜닝) 성능 비교 카드. */
+function PerfCompare({
+  asis,
+  tobe,
+  analyzed,
+}: {
+  asis: { timeMs: number | null; cost: number | null }
+  tobe: { timeMs: number | null; cost: number | null }
+  analyzed?: boolean
+}) {
+  const improve = (a: number | null, b: number | null): string | null =>
+    a != null && b != null && a > 0 ? `${Math.round(((a - b) / a) * 100)}%` : null
+  const timeImp = improve(asis.timeMs, tobe.timeMs)
+  const costImp = improve(asis.cost, tobe.cost)
+  return (
+    <div className="ai-perf">
+      <div className="ai-perf-title">성능 비교</div>
+      <table className="ai-perf-table">
+        <thead>
+          <tr>
+            <th />
+            <th>AS-IS (원본)</th>
+            <th>TO-BE (튜닝)</th>
+            <th>개선</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td className="ai-perf-metric">실행 시간</td>
+            <td>{asis.timeMs != null ? fmtMs(asis.timeMs) : '—'}</td>
+            <td>{tobe.timeMs != null ? fmtMs(tobe.timeMs) : '—'}</td>
+            <td className={timeImp ? 'ai-perf-good' : ''}>{timeImp ? `↓ ${timeImp}` : '—'}</td>
+          </tr>
+          <tr>
+            <td className="ai-perf-metric">예상 비용</td>
+            <td>{asis.cost != null ? asis.cost.toLocaleString() : '—'}</td>
+            <td>{tobe.cost != null ? tobe.cost.toLocaleString() : '—'}</td>
+            <td className={costImp ? 'ai-perf-good' : ''}>{costImp ? `↓ ${costImp}` : '—'}</td>
+          </tr>
+        </tbody>
+      </table>
+      {asis.timeMs == null && (
+        <div className="ai-perf-note">
+          원본을 <b>성능 분석(EXPLAIN ANALYZE)</b> 으로 실행하면 실제 실행 시간까지 비교됩니다
+          {analyzed === false ? ' (지금은 추정 계획이라 비용만 비교).' : '.'}
+        </div>
+      )}
     </div>
   )
 }

--- a/apps/web/src/components/AiFixPanel.tsx
+++ b/apps/web/src/components/AiFixPanel.tsx
@@ -234,10 +234,21 @@ function PerfCompare({
   tobe: { timeMs: number | null; cost: number | null }
   analyzed?: boolean
 }) {
-  const improve = (a: number | null, b: number | null): string | null =>
-    a != null && b != null && a > 0 ? `${Math.round(((a - b) / a) * 100)}%` : null
-  const timeImp = improve(asis.timeMs, tobe.timeMs)
-  const costImp = improve(asis.cost, tobe.cost)
+  // 개선률을 부호로 갈라 셀 내용·색을 정한다.
+  // 양수(빨라짐/비용↓) → 초록 '↓ N%', 음수(느려짐/비용↑) → 앰버 '↑ N% 느려짐', 0/판정불가 → '—'.
+  const delta = (
+    a: number | null,
+    b: number | null,
+    worseLabel: string,
+  ): { text: string; cls: string } => {
+    if (a == null || b == null || a <= 0) return { text: '—', cls: '' }
+    const pct = Math.round(((a - b) / a) * 100)
+    if (pct > 0) return { text: `↓ ${pct}%`, cls: 'ai-perf-good' }
+    if (pct < 0) return { text: `↑ ${-pct}% ${worseLabel}`, cls: 'ai-perf-bad' }
+    return { text: '변화 없음', cls: '' }
+  }
+  const timeImp = delta(asis.timeMs, tobe.timeMs, '느려짐')
+  const costImp = delta(asis.cost, tobe.cost, '늘어남')
   return (
     <div className="ai-perf">
       <div className="ai-perf-title">성능 비교</div>
@@ -255,13 +266,13 @@ function PerfCompare({
             <td className="ai-perf-metric">실행 시간</td>
             <td>{asis.timeMs != null ? fmtMs(asis.timeMs) : '—'}</td>
             <td>{tobe.timeMs != null ? fmtMs(tobe.timeMs) : '—'}</td>
-            <td className={timeImp ? 'ai-perf-good' : ''}>{timeImp ? `↓ ${timeImp}` : '—'}</td>
+            <td className={timeImp.cls}>{timeImp.text}</td>
           </tr>
           <tr>
             <td className="ai-perf-metric">예상 비용</td>
             <td>{asis.cost != null ? asis.cost.toLocaleString() : '—'}</td>
             <td>{tobe.cost != null ? tobe.cost.toLocaleString() : '—'}</td>
-            <td className={costImp ? 'ai-perf-good' : ''}>{costImp ? `↓ ${costImp}` : '—'}</td>
+            <td className={costImp.cls}>{costImp.text}</td>
           </tr>
         </tbody>
       </table>

--- a/apps/web/src/components/Notebook.tsx
+++ b/apps/web/src/components/Notebook.tsx
@@ -277,7 +277,7 @@ function SqlCell({
   onAiModelChange: (v: string) => void
   aiDbConnId?: string
   onInsertAiSqlBelow: (src: string) => void
-  onAiEscalate?: (payload: { sql: string; error: string; assistant: string; dbConnId?: string }) => void
+  onAiEscalate?: (payload: { sql: string; error?: string; explain?: string; assistant: string; dbConnId?: string }) => void
   selected: boolean
   editing: boolean
   register: (id: string, api: CellApi | null) => void
@@ -1095,7 +1095,7 @@ export function Notebook({
   /** ⌘/Ctrl+S·저장 버튼 — 셀을 하나의 SQL 로 합쳐 저장한다(저장됨 탭). */
   onSave?: () => void
   /** 셀 오류 수정 패널의 「AI 탭에서 이어가기」 — 페이지가 처리한다. */
-  onAiEscalate?: (payload: { sql: string; error: string; assistant: string; dbConnId?: string }) => void
+  onAiEscalate?: (payload: { sql: string; error?: string; explain?: string; assistant: string; dbConnId?: string }) => void
 }) {
   const [selId, setSelId] = useState<string | null>(cells[0]?.id ?? null)
   const [editing, setEditing] = useState(false)

--- a/apps/web/src/pages/SqlEditor.tsx
+++ b/apps/web/src/pages/SqlEditor.tsx
@@ -380,7 +380,7 @@ function SessionEditor({
   /** 이 연결에서 사용자가 잠시 꺼 둔 명령 (툴바 태그 클릭). */
   muted: SqlStatement[]
   onToggleMuted: (connId: string, s: SqlStatement) => void
-  onAiEscalate: (payload: { sql: string; error: string; assistant: string; dbConnId?: string }) => void
+  onAiEscalate: (payload: { sql: string; error?: string; explain?: string; assistant: string; dbConnId?: string }) => void
 }) {
   const duck = isDuckSession(session)
   // 파이썬 코드 팝업 — 세션마다 따로 연다 (탭이 여럿이면 각자 자기 쿼리를 보여야 한다)
@@ -613,7 +613,7 @@ function DockView(props: {
   onChangeConn: (sid: number, connId: string) => void
   bindInsert: (sid: number, fn: (text: string) => void) => void
   onFocusSession: (sid: number) => void
-  onAiEscalate: (payload: { sql: string; error: string; assistant: string; dbConnId?: string }) => void
+  onAiEscalate: (payload: { sql: string; error?: string; explain?: string; assistant: string; dbConnId?: string }) => void
   onSaveSession: (payload: {
     sessionId: number
     mode: 'sql' | 'mongo' | 'duck'
@@ -1390,21 +1390,22 @@ export function SqlEditorPage() {
     setSaveReq(null)
   }
 
-  // 오류 수정 패널의 「AI 탭에서 이어가기」 — AI 어시스턴트 탭에 대화를 심고 앞으로 가져온다.
-  const escalateToAi = (p: { sql: string; error: string; assistant: string; dbConnId?: string }) => {
+  // 오류 수정·튜닝 패널의 「AI 탭에서 이어가기」 — AI 어시스턴트 탭에 대화를 심고 앞으로 가져온다.
+  const escalateToAi = (p: { sql: string; error?: string; explain?: string; assistant: string; dbConnId?: string }) => {
     const aiConn = connections.find((c) => specFor(c.type).category === 'ai')
-    const fixedSql = p.assistant.match(/```sql\s*\n([\s\S]*?)```/i)?.[1].trim() || null
+    const outSql = p.assistant.match(/```sql\s*\n([\s\S]*?)```/i)?.[1].trim() || null
+    // fix(오류)냐 tune(계획)이냐에 따라 첫 사용자 메시지를 다르게 짓는다.
+    const userContent = p.error
+      ? `다음 쿼리에서 오류가 났어요. 고쳐 주세요.\n\n\`\`\`sql\n${p.sql}\n\`\`\`\n\n오류:\n${p.error}`
+      : `다음 쿼리를 튜닝하고 싶어요.\n\n\`\`\`sql\n${p.sql}\n\`\`\`` +
+        (p.explain ? `\n\n실행 계획:\n${p.explain}` : '')
     const seeded: ChatState = {
       aiConnId: aiConn?.id,
       dbConnId: p.dbConnId,
-      intent: 'sql.generate',
+      intent: p.error ? 'sql.generate' : 'sql.tune',
       messages: [
-        {
-          id: chatUid(),
-          role: 'user',
-          content: `다음 쿼리에서 오류가 났어요. 고쳐 주세요.\n\n\`\`\`sql\n${p.sql}\n\`\`\`\n\n오류:\n${p.error}`,
-        },
-        { id: chatUid(), role: 'assistant', content: p.assistant, sql: fixedSql },
+        { id: chatUid(), role: 'user', content: userContent },
+        { id: chatUid(), role: 'assistant', content: p.assistant, sql: outSql },
       ],
     }
     saveChat(AI_TAB, seeded)

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -7816,6 +7816,7 @@ tbody tr:hover {
 .ai-perf-table tbody tr:last-child td { border-bottom: 0; }
 .ai-perf-metric { text-align: left !important; font-weight: 600; color: var(--ink); }
 .ai-perf-good { color: #16a34a; font-weight: 700; }
+.ai-perf-bad { color: #b45309; font-weight: 700; }
 .ai-perf-note {
   padding: 7px 10px;
   font-size: 11.5px;

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -3211,6 +3211,11 @@ body.resizing-col .config-resizer::after {
 .obj-sec-hd h4 {
   margin: 0;
 }
+.obj-sec-actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
 .obj-table-wrap {
   overflow-x: auto;
   border: 1px solid var(--line2);
@@ -7776,6 +7781,47 @@ tbody tr:hover {
   flex-wrap: wrap;
   gap: 6px;
   margin-top: 10px;
+}
+.ai-perf {
+  margin-top: 12px;
+  border: 1px solid #e5e0f5;
+  border-radius: 8px;
+  overflow: hidden;
+}
+.ai-perf-title {
+  padding: 6px 10px;
+  font-size: 11.5px;
+  font-weight: 700;
+  color: #6d28d9;
+  background: #f5f1fe;
+  border-bottom: 1px solid #ece6fb;
+}
+.ai-perf-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 12.5px;
+}
+.ai-perf-table th,
+.ai-perf-table td {
+  padding: 6px 10px;
+  text-align: right;
+  border-bottom: 1px solid #f0edf9;
+}
+.ai-perf-table thead th {
+  font-size: 11px;
+  font-weight: 700;
+  color: #8b8f9c;
+  background: #fbfaff;
+}
+.ai-perf-table tbody tr:last-child td { border-bottom: 0; }
+.ai-perf-metric { text-align: left !important; font-weight: 600; color: var(--ink); }
+.ai-perf-good { color: #16a34a; font-weight: 700; }
+.ai-perf-note {
+  padding: 7px 10px;
+  font-size: 11.5px;
+  color: #8b6d00;
+  background: #fffbeb;
+  border-top: 1px solid #f0edf9;
 }
 
 /* ── 셀별 AI 챗 (노트북) ── 셀 아래에 붙는 작은 대화창 */


### PR DESCRIPTION
## 변경 요약

AI 쿼리 튜닝을 **실제 실행 계획(EXPLAIN) 기반**으로 강화하고, 튜닝 전후 **AS-IS/TO-BE 성능 비교**를 붙인다.

**계획 기반 튜닝 (`apps/api`, `apps/web`)**
- `sql.tune` 이 이제 실제 EXPLAIN 계획을 문맥으로 받아, 추측이 아니라 계획에서 드러난 병목(풀스캔·함수로 감싼 인덱스 미사용·과도한 정렬·상관 서브쿼리 반복)을 근거로 튜닝하고 필요 시 `CREATE INDEX` 를 제안한다(실행은 하지 않음). `AiChatRequest.explain` 필드 추가.
- EXPLAIN 결과 모달에 **「AI 튜닝」** 버튼 — 쿼리+계획을 AI 에 보내 진단·튜닝 쿼리를 그 자리에서 받고 편집기에 적용(되돌리기 가능), 부족하면 「AI 탭에서 이어가기」로 대화 승격.

**AS-IS/TO-BE 성능 비교 (`apps/web`)**
- 튜닝 결과에 **「성능 비교」** — 튜닝된 쿼리를 EXPLAIN ANALYZE 로 재보고 원본과 실행 시간·예상 비용을 표로 견준다(MySQL·PostgreSQL 파싱). 빨라지면 초록 ↓, 느려지면 앰버 ↑ 로 방향을 구분.

**정리**
- 오류 수정 패널(`AiFixPanel`)을 fix/tune 공용으로 일반화 — 새 표면 없이 재사용.
- 실행 계획 헤더 버튼을 오른쪽 그룹으로 정렬.

## 테스트 방법

- `cd apps/api && uv run --extra dev pytest` → **532 passed** (계획 기반 튜닝 테스트 포함).
- `cd apps/web && npm ci && npm test` → **281 passed / 1 failed**. 실패 1건은 이번 PR 이 건드리지 않은 `savedStore.test.ts` 의 기존 환경 이슈(macOS jsdom `localStorage`)로, CI(Ubuntu)에서는 통과한다.

## 코드리뷰

**이번 review 요약**: 확정 수정 1건(성능 비교의 개선률 부호 처리 수정), 다음 검토로 이월 1건.

### 알려진 제약 사항 (이번 PR 미반영, 후속 검토 필요)

#### 1. EXPLAIN 계획 텍스트가 예시-데이터 토글을 거치지 않고 외부 AI 로 전송된다

- **위치**: `apps/web/src/components/AiFixPanel.tsx:397`
- **문제**: AI 튜닝은 쿼리의 실행 계획(EXPLAIN/EXPLAIN ANALYZE) 텍스트를 외부 AI 제공자에게 보내는데, 이 텍스트에는 테이블·컬럼 이름, 쿼리에 쓰인 조건 값, 실제 처리 행 수 추정치가 들어갈 수 있다. 예시 데이터 전송은 기본으로 꺼 두는 정책(`include_samples`)이 있는 반면, 실행 계획 전송은 그 토글을 거치지 않는다.
- **왜 이번 PR 에 안 넣었나**: 사용자가 직접 「AI 튜닝」을 눌러 유발하는 전송이고 쿼리 본문(`sql`)은 이미 전송 중이라 위험 증가폭이 작다 — 계획 전송에도 같은 수준의 고지/동의(토글)를 둘지는 정책 판단 사항으로 후속 검토한다.
