### PR TITLE
fix(worker): consolidate CDC sink datetime imports

### DIFF
--- a/apps/worker/src/eai_worker/cdc_sink.py
+++ b/apps/worker/src/eai_worker/cdc_sink.py
@@ -27,7 +27,7 @@ import types
 from collections import defaultdict
 from collections.abc import Callable
 from dataclasses import dataclass
-from datetime import UTC
+from datetime import UTC, datetime
 from enum import StrEnum
 from typing import Any, Protocol
 
@@ -436,8 +436,6 @@ def _report_metrics(counts: dict[str, int], last_ts: dict[str, int]) -> None:
     """
     if not counts:
         return
-    from datetime import datetime
-
     from eai_api.db import session_scope
     from eai_api.models import CdcStream
 


### PR DESCRIPTION
Closes #41.

Moves `datetime` alongside `UTC` in the CDC sink's module-level imports, so the standard-library datetime dependency has one clear import location.

Validation:
- uv run --python 3.12 --extra dev pytest -q tests/test_cdc_sink.py (25 passed)
- uv run --python 3.12 --extra dev ruff check src/eai_worker/cdc_sink.py

The complete worker suite is blocked only by pre-existing Windows incompatibility in the Python sandbox tests: they call `select.select()` on subprocess pipes, which raises WinError 10038 on this platform.