### PR TITLE
docs: 설계 문서를 마크다운으로 옮기고 시연 스택을 잇는다

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,8 @@
 
 > 이 문서는 **Claude Code**가 이 프로젝트를 이해하고 구현하도록 돕는 최상위 컨텍스트 파일입니다.
 > 저장소 루트에 `CLAUDE.md`로 두면 Claude Code가 자동으로 읽어 들입니다.
-> 상세 아키텍처는 `docs/EAI_아키텍처_설계문서.docx`, UI 레퍼런스는 `docs/mockups/*.html`를 참고하세요.
+> 상세 아키텍처는 [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md), UI 레퍼런스는 `docs/mockups/*.html`를 참고하세요.
+> 원본 기획 문서(`docs/EAI_아키텍처_설계문서.docx` · `.pdf`)는 부록입니다 — 바이너리라 diff 가 되지 않습니다.
 
 ---
 
@@ -51,7 +52,8 @@ eai-platform/
 ├── CLAUDE.md                      # 이 파일
 ├── docker-compose.yml             # 로컬/EC2 단일노드 실행
 ├── docs/
-│   ├── EAI_아키텍처_설계문서.docx
+│   ├── ARCHITECTURE.md            # 구조·실행 모델·커넥터 계약 (설계의 진실)
+│   ├── EAI_아키텍처_설계문서.docx  # 원본 기획 (부록)
 │   └── mockups/                   # UI 레퍼런스 (HTML)
 ├── apps/
 │   ├── api/                       # FastMCP + FastAPI 백엔드
@@ -221,25 +223,34 @@ WS     /runs/{id}/stream           # 실시간 로그/진행률
 > 이 절은 **`README.md` 「빠른 시작」·「테스트 · 품질」과 `.github/workflows/ci.yml` 을 따른다.**
 > 셋이 갈라지면 낡은 쪽은 여기다 — 실제로 도는 것은 CI 뿐이므로 거기를 진실로 본다.
 
+파이썬 명령은 전부 **`uv run`** 을 거친다. `uv run` 은 그 디렉터리의 프로젝트 환경을 알아서
+잡아(없으면 만들고 의존성을 맞춘 뒤) 그 안에서 실행하므로, **venv 를 활성화하지 않은 셸에
+그대로 붙여 넣어도 돈다.** 아래 「테스트·린트」의 경고와 같은 이유다 — 맨 이름으로 부르면
+없거나 다른 것이 잡힌다.
+
 ```bash
 # 전체 로컬 기동
 docker compose up -d
 
 # 백엔드
-cd apps/api && alembic upgrade head && uvicorn eai_api.main:app --reload
+cd apps/api && uv run alembic upgrade head && uv run uvicorn eai_api.main:app --reload
 
 # 워커 (Celery 앱은 celery_app.py 에 있다. 태스크는 autodiscover 로 붙는다)
-celery -A eai_worker.celery_app:app worker -l info -Q eai.default
-python -m eai_worker.scheduler
+cd apps/worker && uv run celery -A eai_worker.celery_app:app worker -l info -Q eai.default
+cd apps/worker && uv run python -m eai_worker.scheduler
 
 # 프론트엔드
 cd apps/web && npm install && npm run dev
 
 # DB 마이그레이션
-cd apps/api && alembic upgrade head
+cd apps/api && uv run alembic upgrade head
 ```
 
-테스트·린트는 **`uv run --extra dev`** 를 거친다. `pytest`·`ruff`·`mypy` 는
+> README 「빠른 시작」의 로컬 개발 절은 같은 명령을 **맨 이름으로** 적는다. 그쪽은 루트에
+> `uv venv` 로 만든 환경을 **활성화한 셸**을 전제한 형태이고, 위는 활성화 없이도 도는 형태다.
+> 결과는 같다 — 붙여 넣어 바로 돌리려면 위를 쓴다.
+
+테스트·린트도 같은 방식이되 **`--extra dev`** 가 붙는다. `pytest`·`ruff`·`mypy` 는
 `[project.optional-dependencies].dev` 에 있어 `uv sync` 만으로는 설치되지 않고,
 venv 를 활성화하지 않은 셸에서 맨 이름으로 부르면 없거나 **다른 것이 잡힌다.**
 `<영역>` 은 `connectors`·`api`·`worker`·`sap-connector`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -218,24 +218,40 @@ WS     /runs/{id}/stream           # 실시간 로그/진행률
 
 ## 12. 개발 명령어 (참고)
 
+> 이 절은 **`README.md` 「빠른 시작」·「테스트 · 품질」과 `.github/workflows/ci.yml` 을 따른다.**
+> 셋이 갈라지면 낡은 쪽은 여기다 — 실제로 도는 것은 CI 뿐이므로 거기를 진실로 본다.
+
 ```bash
 # 전체 로컬 기동
 docker compose up -d
 
 # 백엔드
-cd apps/api && uv sync && uvicorn eai_api.main:app --reload
-cd apps/api && pytest && ruff check . && mypy .
+cd apps/api && alembic upgrade head && uvicorn eai_api.main:app --reload
 
-# 워커
-cd apps/worker && celery -A eai_worker.tasks worker -l info
+# 워커 (Celery 앱은 celery_app.py 에 있다. 태스크는 autodiscover 로 붙는다)
+celery -A eai_worker.celery_app:app worker -l info -Q eai.default
+python -m eai_worker.scheduler
 
 # 프론트엔드
-cd apps/web && pnpm i && pnpm dev
-cd apps/web && pnpm test && pnpm lint
+cd apps/web && npm install && npm run dev
 
 # DB 마이그레이션
 cd apps/api && alembic upgrade head
 ```
+
+테스트·린트는 **`uv run --extra dev`** 를 거친다. `pytest`·`ruff`·`mypy` 는
+`[project.optional-dependencies].dev` 에 있어 `uv sync` 만으로는 설치되지 않고,
+venv 를 활성화하지 않은 셸에서 맨 이름으로 부르면 없거나 **다른 것이 잡힌다.**
+`<영역>` 은 `connectors`·`api`·`worker`·`sap-connector`.
+
+```bash
+cd apps/<영역> && uv run --extra dev pytest -q && uv run --extra dev ruff check .
+cd apps/web && npm test && npm run lint && npm run build
+```
+
+**`mypy` 는 여기 없다.** src 기준 127건이 남아 있어 지금 넣으면 항상 실패한다 —
+CI 게이트가 아닌 이유와 같다(`ci.yml` 머리말). 줄여 나가는 중이며 확인은
+`cd apps/<영역> && uv run --extra dev mypy .` 로 따로 한다.
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,8 @@ ditter 에 관심을 가져 주어 고맙다. 이 문서는 **어디를 먼저 �
 | 궁금한 것 | 문서 |
 |---|---|
 | 이 프로젝트가 무엇인가 · 어떻게 띄우나 | [README.md](README.md) |
-| 왜 그렇게 만들었나 (설계 결정과 그 근거) | [CLAUDE.md](CLAUDE.md) |
+| 어떻게 짜여 있나 (구조·실행 모델·커넥터 계약) | [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) |
+| 왜 그렇게 만들었나 (기능별 결정 근거의 전문) | [CLAUDE.md](CLAUDE.md) |
 | 커밋·브랜치·머지 규칙 | [docs/conventions/commit-convention.md](docs/conventions/commit-convention.md) |
 | 취약점을 발견했을 때 | [SECURITY.md](SECURITY.md) |
 | 직접 굴려 보고 싶을 때 | [demo/README.md](demo/README.md) |

--- a/README.md
+++ b/README.md
@@ -16,8 +16,10 @@
   **로컬 오픈웨이트 모델(Ollama)** 로 상용 API 없이 돌아간다. Gemini·Bedrock 은 선택지 중 하나다.
 - **MCP** — 모든 기능을 MCP tool 로 노출해, UI 와 LLM/에이전트가 **같은 서비스 계층**을 재사용한다.
 
-상세 설계는 [docs/EAI_아키텍처_설계문서.pdf](docs/EAI_아키텍처_설계문서.pdf),
+상세 설계는 [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md),
 구현 가이드는 [CLAUDE.md](CLAUDE.md)를 참고.
+원본 기획 문서([docx](docs/EAI_아키텍처_설계문서.docx) · [pdf](docs/EAI_아키텍처_설계문서.pdf))는
+**부록**으로 남는다 — 바이너리라 diff 도 리뷰도 되지 않는다.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -188,6 +188,50 @@ cd apps/api && python -m eai_api.cli create-admin admin@company.com
 
 ---
 
+## 직접 해보기 — 시연용 가상 DB
+
+빈 화면으로는 이 도구가 무엇을 하는지 보이지 않는다. 그래서 **한 회사의 세 시스템이 서로 다른
+DB 에 흩어진 상황**을 로컬에 그대로 재현해 두었다.
+
+| DB | 무엇이 들어 있나 |
+|---|---|
+| MySQL `shop` | 온라인 쇼핑몰 — 주문·고객·상품·결제 |
+| SQL Server `wms` | 사내 온프레미스 창고관리 — 재고·로케이션·입출고 |
+| PostgreSQL `crm` / `dw` | 고객센터 클레임 / **적재 타깃(비어 있음)** |
+
+*주문은 MySQL, 재고는 사내 MSSQL, 클레임은 PostgreSQL 에 있다. 지연 주문의 원인을 보려면
+지금은 세 팀에 각각 물어봐야 한다* — [연합 조회](#연합-조회--서로-다른-db-를-한-select-로)와
+[파이프라인](#파이프라인-캔버스)이 답하는 것이 이 상황이다.
+
+**본체 스택을 먼저 띄워야 한다.** 데모 DB 는 본체가 만든 네트워크에 올라타므로, api·worker 가
+`mysql-shop:3306` 처럼 컨테이너 이름으로 찾아간다.
+
+```bash
+docker compose up -d
+```
+
+```bash
+bash demo/scripts/up.sh
+```
+
+```bash
+bash demo/scripts/seed.sh
+```
+
+`up.sh` 는 컨테이너와 스키마까지, `seed.sh` 는 목데이터를 넣는다(수 분). **난수 시드가 고정**이라
+`bash demo/scripts/reset.sh` 로 지웠다 다시 만들어도 화면의 숫자가 같다.
+
+계정은 역할별로 나뉜다 — `eai_ro`(조회만) · `eai_rw`(DML) · `eai_ddl`(DDL). 화면의
+[허용 명령](#sql-콘솔)만이 아니라 **DB 권한으로도** 읽기 전용이 기본이라는 것을 보여주는 자리다.
+
+접속 정보·데이터 설계·주의사항은 [demo/README.md](demo/README.md). 위 [「화면」](#화면)의
+스크린샷 세 장도 전부 이 스택으로 찍었다.
+
+> 본체와 **별도 도커 프로젝트**라 `bash demo/scripts/down.sh -v` 한 번이면 볼륨까지
+> 흔적 없이 사라진다. 사내 실데이터는 넣지 않는다 — 그러라고 만든 것이 이 스택이다.
+
+---
+
 ## 테스트 · 품질
 
 Python 앱은 `uv`, 웹은 `npm` 으로 돌린다. `<영역>` 은 `connectors`·`api`·`worker`·`sap-connector`.

--- a/README.md
+++ b/README.md
@@ -293,6 +293,9 @@ docs/           설계 문서, UI 목업, 아키텍처 다이어그램
 
 > 다이어그램 원본(`.dot`)은 [docs/diagrams/](docs/diagrams/) 에 있다 — 고쳐서 다시 그릴 수 있다.
 
+구조와 설계 결정의 전문은 **[docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)** 에 있다 —
+실행 모델과 그 의도된 한계, 커넥터 계약, 새 것을 붙이는 법, 그리고 **택하지 않은 것과 그 이유**.
+
 ---
 
 ## 알아둘 설계 결정

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -29,7 +29,7 @@ ditter 가 어떻게 짜여 있고, **왜 그렇게 됐는지**. 코드를 읽�
 
 ```
 apps/
-  api/             FastAPI(REST·WS) + FastMCP.  메타DB 의 유일한 주인
+  api/             FastAPI(REST·WS) + FastMCP.  메타DB 스키마·마이그레이션의 주인
   worker/          Celery.  파이프라인 실행 엔진
   connectors/      공유 커넥터 라이브러리 — api·worker 양쪽이 쓴다
   sap-connector/   NW RFC SDK 사이드카 (라이선스 바이너리 격리)
@@ -78,6 +78,13 @@ api  <──────────────[worker 가 eai-api 패키지를
 않아 대용량에서 메모리가 상수로 유지된다.
 
 ![파이프라인 실행](diagrams/d2_pipeline.png)
+
+> 이 그림은 **진행률이 화면에 닿는 경로가 실제와 다르다.** 그림은 메타DB 에서
+> WebSocket 으로 화살표를 그렸지만, 실제로는 워커가 Redis Pub/Sub 로 publish 하고
+> ([`services/events.py`](../apps/api/src/eai_api/services/events.py)) API 의 WebSocket 이 구독해
+> 밀어 준다. 그 구분이 중요하다 — **이벤트는 부가 채널이고 진실의 원천은 언제나 메타DB 다.**
+> 구독자가 없어 이벤트를 놓쳐도 UI 는 REST 폴백으로 같은 상태를 복원한다. 그림은 이 둘을 뒤집어
+> 놓았다. `Main (Orchestrator)` 도 별도 프로세스가 아니라 api 안이다.
 
 ### 이 모델이 만드는 결과들
 
@@ -206,12 +213,6 @@ User         email · password_hash(Argon2id) · role · external_id
 동기화 경로는 **구현은 끝났지만 실환경 검증 전이고, 트리거 기반이라 운영 적용 전 부하 테스트가
 게이트다.** 착수 점검(`sync_service.preflight`)이 그 게이트를 코드로 강제한다 — 다만 부하 테스트
 여부는 코드가 판정할 수 없어 경고로만 알린다.
-
-![원본 기획의 수집 경로 — ① 배치 ② SAP RFC ③ CDC(Debezium)](diagrams/d3_ingestion.png)
-
-> 이 그림이 나누는 셋은 위 표와 **기준이 다르다.** 그림은 원본 기획의 「무엇에서 읽는가」
-> (배치 · SAP · CDC)이고, 위 표는 「변경을 어떻게 잡는가」(배치 · CDC · 동기화)다.
-> SymmetricDS 는 그림보다 나중에 붙어 여기 없다.
 
 ---
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,419 @@
+# 아키텍처
+
+ditter 가 어떻게 짜여 있고, **왜 그렇게 됐는지**. 코드를 읽기 전에 알면 시간을 아끼는 것들이다.
+
+이 문서가 다루는 것은 구조와 결정이다. 기능별 사용법은 [README](../README.md), 저장소에서
+일할 때의 규칙은 [CLAUDE.md](../CLAUDE.md), 커밋·브랜치 규칙은
+[docs/conventions/](conventions/) 에 있다.
+
+원본 기획 문서(`EAI_아키텍처_설계문서.docx` · `.pdf`)는 부록으로 남는다 — 바이너리라 diff 도
+리뷰도 되지 않아, **설계의 진실은 이 문서와 코드**다. 둘이 갈리면 낡은 쪽이 문서다.
+
+---
+
+## 1. 한눈에
+
+이기종 저장소(RDB · NoSQL · SAP)의 데이터를 표준화된 방식으로 모아 목적 저장소(DB · S3)로
+적재하는 자체 EAI 플랫폼이다. 두 얼굴이 있다.
+
+- **SQL 콘솔** — 여러 연결을 한 화면에서 조회한다. 서로 다른 DB 를 한 SELECT 로 조인하는
+  [연합 조회](#8-이기종-연합-조회--duckdb)까지 포함한다.
+- **파이프라인 캔버스** — 드래그앤드롭으로 수집·변환·적재를 엮어 배치/실시간으로 돌린다.
+
+![전체 구조 — 프레젠테이션 · API/BFF(FastMCP) · 오케스트레이션/실행 · 커넥터 · 소스/타깃 계층](diagrams/d1_overall.png)
+
+> 이 그림은 **파이프라인 쪽**을 담았다. SQL 콘솔·연합 조회·AI 어시스턴트는 여기 그려진 것과
+> 같은 API 계층 위에 얹힌다. 인증은 현재 **JWT + RBAC** 이고 그림의 `OAuth2` 는 아직
+> 스키마(`users.external_id`)만 준비된 상태다 — 그림 수정은
+> [#66](https://github.com/SurvivorsStudio/ditter/issues/66).
+
+```
+apps/
+  api/             FastAPI(REST·WS) + FastMCP.  메타DB 의 유일한 주인
+  worker/          Celery.  파이프라인 실행 엔진
+  connectors/      공유 커넥터 라이브러리 — api·worker 양쪽이 쓴다
+  sap-connector/   NW RFC SDK 사이드카 (라이선스 바이너리 격리)
+  web/             React 18 + React Flow
+cdc/debezium/      Kafka Connect 구성
+sync/symmetricds/  트리거 기반 실시간 동기화 구성
+```
+
+| 영역 | 기술 |
+|---|---|
+| 프런트 | React 18 · TypeScript · Vite · React Flow · Zustand · TanStack Query |
+| 백엔드 | Python 3.12 · FastAPI · FastMCP · SQLAlchemy 2.x · Pydantic v2 |
+| 실행 | Celery + Redis · 커스텀 DAG 오케스트레이터 |
+| 메타데이터 | PostgreSQL 16 (Alembic 마이그레이션 7개) |
+| 실시간 | Debezium(Kafka Connect) · SymmetricDS |
+| 분석 | DuckDB + polars (연합 조회) |
+
+---
+
+## 2. 의존 방향 — api 와 worker 는 한쪽으로만 안다
+
+가장 먼저 알아야 할 것이다.
+
+```
+api  ──[Redis 큐: send_task("eai_worker.tasks.execute_pipeline")]──>  worker
+api  <──────────────[worker 가 eai-api 패키지를 import]──────────────  worker
+```
+
+**api 는 worker 코드를 import 하지 않는다.** 이름만 큐에 넣는다
+([`run_service.py`](../apps/api/src/eai_api/services/run_service.py)). 반대로 worker 는 메타DB 를
+직접 갱신해야 하므로 `eai-api` 패키지(모델·서비스·DAG 스펙)에 의존한다.
+
+그래서 DAG 스펙(`eai_api.schemas.dag`)을 **양쪽이 공유한다.** 정의를 복제하면 반드시 어긋난다.
+
+`apps/connectors/` 는 그 아래에 있다 — api(연결 테스트·스키마 탐색·쿼리)와 worker(실제 적재)가
+같은 계약을 쓴다. 그래서 **커넥터 변경은 항상 먼저 커밋한다.** 계약이 깨지면 양쪽에서 드러나야 한다.
+
+---
+
+## 3. 실행 모델 — 타깃 주도 풀 스트리밍
+
+파이프라인은 노드와 엣지로 된 DAG 다. 실행은 **타깃이 당기는 방향**으로 일어난다.
+
+타깃마다 상류를 거슬러 제너레이터 체인을 만들고, 타깃이 배치를 당겨오면서 흐름이 생긴다
+([`engine._build_stream`](../apps/worker/src/eai_worker/engine.py)). 중간 결과가 메모리에 쌓이지
+않아 대용량에서 메모리가 상수로 유지된다.
+
+![파이프라인 실행](diagrams/d2_pipeline.png)
+
+### 이 모델이 만드는 결과들
+
+**소스 앞에는 트리거만 올 수 있다.** `_stream_of` 는 소스를 만나면 상류를 조립하지 않고 곧장
+`read()` 한다. 소스→소스로 이어 두면 화면에는 이어져 보이고 실행도 성공하는데 상류 데이터만
+조용히 사라진다. 가장 찾기 어려운 종류라 **양쪽에서 막았다** — 캔버스 `onConnect` 가 연결 자체를
+거절하고, 저장된 정의는 검증이 에러로 잡는다.
+
+> 이것이 이 저장소의 반복되는 규칙이다: **못 하는 일은 그릴 수 없게 한다.** 그릴 수 있는데
+> 아무 일도 안 일어나는 것이 가장 나쁜 결과다.
+
+**여러 상류가 한 노드로 모이면 순차 concat(UNION ALL)이다.** 조인은 노드로 지원하지 않는다.
+
+**한 노드가 여러 소비자를 가지면 스풀로 팬아웃한다.** 첫 소비 때 JSONL 로 디스크에 적고 나머지는
+되읽는다([`spool.py`](../apps/worker/src/eai_worker/spool.py)). 소스는 정확히 한 번만 읽힌다.
+대신 **엔진은 타깃을 순차 실행해야 한다** — 병렬로 돌리면 스풀이 완성되기 전에 두 번째 소비자가
+붙어 `_replay` 가 `RuntimeError` 를 던진다.
+
+### 순서가 중요한 것
+
+- **워터마크는 모든 타깃이 성공한 뒤에만 전진한다.** 적재 전에 올리면 실패 구간이 영구 유실된다.
+  체크포인트 저장 실패는 Run 을 실패로 만든다 — 조용히 넘어가면 다음 실행이 같은 구간을 건너뛴다.
+- **DB overwrite 는 첫 배치에서만 테이블을 비운다.** 매 배치 비우면 마지막 배치만 남는다.
+- **S3 overwrite 는 적재 전에 `run_id=` prefix 를 정리한다.** 재시도 시 이전 파트가 중복으로 남는다.
+
+---
+
+## 4. 커넥터 계약
+
+새 소스·타깃을 붙이는 것은 [`BaseConnector`](../apps/connectors/src/eai_connectors/base.py)
+프로토콜 하나를 구현하는 일이다.
+
+```python
+class BaseConnector(Protocol):
+    def test_connection(self) -> HealthResult: ...
+    def discover_schema(
+        self, table: str | None = None, *, include_pk: bool = True, include_columns: bool = True
+    ) -> list[TableSchema]: ...
+    def read(self, spec: ReadSpec) -> Iterator[RecordBatch]: ...
+    def write(self, batch: RecordBatch, mode: WriteMode) -> WriteResult: ...
+    def close(self) -> None: ...
+```
+
+`discover_schema` 의 `table` 인자는 SAP 때문에 생겼다. **SAP 은 테이블이 수만 개라 열거가
+불가능**하므로 그쪽에서는 사실상 필수이고, RDB·Mongo 에서는 지정 시 조회 비용을 아끼는
+최적화가 된다. 연결은 "어디에 붙는가"이지 "무엇을 읽는가"가 아니다 — 그래서 읽을 대상은
+연결이 아니라 이 인자와 노드 설정이 정한다.
+
+- **`read` 는 제너레이터다.** 한 번에 다 읽지 않는다. 증분키·워터마크는 `ReadSpec` 으로 받는다.
+- **커넥터별 옵션은 `ReadSpec.params` 로만 전달된다.** 새 커넥터를 만들 때 기억할 것.
+- 커넥션 풀을 유지하고 재시도(지수 백오프)를 내장한다([`retry.py`](../apps/connectors/src/eai_connectors/retry.py)).
+
+### `ReadSpec` — 소스를 가리키는 세 가지 방법
+
+`table` · `query` · `function` 중 **하나는 반드시** 있어야 한다.
+
+처음에는 `table | query` 둘뿐이었다. SAP BAPI 를 붙이면서 **둘 다 아닌 소스**가 나왔고,
+워크어라운드 대신 계약을 고쳤다. 계약이 현실을 못 담으면 계약을 고치는 것이 맞다.
+
+### 지금 있는 커넥터
+
+| 종류 | 커넥터 |
+|---|---|
+| SQL | `mysql` · `postgres` · `mssql` (`SqlConnector` 상속 — URL·MERGE 문만 다르다) |
+| 문서 | `mongo` (스키마가 없어 `BaseConnector` 를 독립 구현) |
+| 객체 | `s3` · `local_file` |
+| 원격 함수 | `sap_rfc` (사이드카 경유) |
+| AI 모델 | `gemini` · `bedrock` · `ollama` |
+
+`registry.py` 가 **지연 로딩**한다. 임포트 시점에 드라이버를 다 불러오면 fork 하는 순간 드러난다
+([§10](#10-임포트는-싸야-한다)).
+
+### AI 모델도 커넥터다
+
+`ai_service.chat()` 은 `.generate()` 를 가진 커넥터면 무엇이든 받는다 — **벤더를 모른다.**
+그래서 Ollama(로컬 오픈웨이트) 지원을 더하는 데 커넥터 하나를 추가하는 것으로 끝났고,
+서비스·라우터·프론트 로직은 손대지 않았다.
+
+이것이 "AI 를 어떻게 붙일 것인가"에 대한 이 저장소의 답이다. **AI 를 특별 취급하지 않는다.**
+
+---
+
+## 5. 메타데이터 모델
+
+```
+Connection   type · config(jsonb) · secret_ref · allowed_statements · auto_commit
+Pipeline     definition(jsonb: nodes+edges) · version · schedule(cron)
+Run          status · trigger · started_at · records · node_states(jsonb)
+RunLog       run_id · node_id · level · message
+Checkpoint   pipeline_id · node_id · watermark / cdc_offset(jsonb)
+CdcStream    engine(debezium | symmetricds) · status · config(jsonb)
+User         email · password_hash(Argon2id) · role · external_id
+```
+
+- **시크릿 원문은 저장하지 않는다.** `secret_ref` 만 두고 실제 값은 KMS/시크릿 매니저에서 복호화한다.
+  [`schemas/connection.py`](../apps/api/src/eai_api/schemas/connection.py) 의 `SECRET_KEYS` 에 든
+  필드는 평문으로 메타DB 에 남지 않는다 — DB 를 직접 봐도 흔적이 없다. 커넥터를 추가하면서
+  비밀 성격의 키를 빠뜨리는 것을 **테스트가 막는다**(`test_secret_coverage.py`).
+- **`definition` 은 노드·엣지를 담은 DAG 다.** 실행 시 위상 정렬 후 처리한다.
+- **컬럼을 함부로 늘리지 않는다.** `allowed_statements`·`auto_commit` 은 타입마다 다른 정책이라
+  `config` 안에 산다 — 마이그레이션도 필요 없다.
+
+### 워터마크에는 타입 태그가 붙는다
+
+`datetime`·`Decimal` 워터마크는 JSONB 에 그대로 들어가지 않는다. `engine._encode_watermark` 가
+타입 태그를 붙여 저장한다 — **태그를 잃으면 다음 비교가 조용히 어긋난다.**
+
+---
+
+## 6. 수집 방식 세 갈래
+
+같은 문제(원본의 변경을 타깃으로 옮긴다)에 대한 답이 셋이고, **고르는 기준이 다르다.**
+
+| | 배치 | CDC (Debezium) | 동기화 (SymmetricDS) |
+|---|---|---|---|
+| 잡는 법 | 주기적 조회 (watermark) | DB 로그(binlog·WAL) | 원본 테이블에 **트리거** |
+| 지연 | 스케줄 주기 | 초 단위 | 라우팅 주기(기본 10초) |
+| 원본 부담 | 조회 부하 | 거의 없음 | **쓰기마다 트리거** |
+| 데이터가 지나는 곳 | 워커 | Kafka → 워커 | **워커를 지나지 않는다** |
+| 변환·컬럼 매핑 | 된다 | 된다 | **불가능** |
+| 언제 쓰나 | 기본 | 원본이 로그 기반 CDC 를 지원 | 원본이 CDC 를 못 쓸 때 |
+
+**동기화만 데이터가 우리 프로세스를 지나지 않는다.** SymmetricDS 가 원본에서 타깃 DB 로 직접
+옮긴다. 그래서 변환·다중 타깃이 성립하지 않고, 캔버스와 검증 양쪽에서 그리지 못하게 막는다.
+
+동기화 경로는 **구현은 끝났지만 실환경 검증 전이고, 트리거 기반이라 운영 적용 전 부하 테스트가
+게이트다.** 착수 점검(`sync_service.preflight`)이 그 게이트를 코드로 강제한다 — 다만 부하 테스트
+여부는 코드가 판정할 수 없어 경고로만 알린다.
+
+![원본 기획의 수집 경로 — ① 배치 ② SAP RFC ③ CDC(Debezium)](diagrams/d3_ingestion.png)
+
+> 이 그림이 나누는 셋은 위 표와 **기준이 다르다.** 그림은 원본 기획의 「무엇에서 읽는가」
+> (배치 · SAP · CDC)이고, 위 표는 「변경을 어떻게 잡는가」(배치 · CDC · 동기화)다.
+> SymmetricDS 는 그림보다 나중에 붙어 여기 없다.
+
+---
+
+## 7. SAP — 라이선스 바이너리를 격리한다
+
+```
+worker ──HTTP──> sap-connector 사이드카 ──RFC──> SAP
+ (SDK 없음)              (SDK 여기만)
+```
+
+NW RFC SDK 는 SAP 라이선스가 있어야 받는 **독점 바이너리**라 저장소에도 pip 에도 없다. 워커
+이미지에 넣으면 SAP 를 안 쓰는 파이프라인까지 그 이미지에 묶인다.
+
+`eai_connectors/sap_rfc.py` 는 SAP 라이브러리를 **한 줄도 임포트하지 않는다.**
+
+**접속 정보와 SDK 는 다른 문제다.** 처음엔 둘을 묶어 사이드카 `.env` 에 뒀는데, 그러면 SAP
+시스템마다 컨테이너를 새로 띄워야 했다. 지금은 갈라져 있다 — 접속 정보는 다른 커넥터처럼
+**연결 설정에 암호화 저장**되고 요청 body 로 전달된다. 사이드카는 접속 정보별로 커넥션을
+캐시하는 **순수 게이트웨이**다.
+
+SDK 없이 개발·검증할 수 있도록 목 백엔드가 있는데, **제약을 눙치지 않는다** — 512자 행폭, 72자
+OPTIONS 줄, ROWSKIPS/ROWCOUNT 를 SAP 과 똑같이 강제한다. 제약을 봐주는 목은 분할 로직을
+검증하지 못하므로 있으나 마나다.
+
+### `RFC_READ_TABLE` 의 함정 둘
+
+1. **행 폭 512자** — 넘으면 필드를 그룹으로 쪼개 여러 번 부르고 행 위치로 병합한다. 그런데 SAP 은
+   `ORDER BY` 없이 순서를 보장하지 않으므로, 그룹 간 행 수가 다르면 **조용히 잇지 않고
+   `SPLIT_ROW_MISMATCH` 로 실패시킨다.**
+2. **OPTIONS 한 줄 72자** — WHERE 절을 자르되 **토큰 경계에서만** 잘라야 한다. 리터럴 중간에서
+   끊으면 ABAP 이 거부한다.
+
+**BAPI 는 예외를 던지지 않는다.** 실패해도 호출은 성공하고 `RETURN` 테이블에 `E`/`A` 메시지가
+담긴다. 확인하지 않으면 실패를 성공으로 착각한다.
+
+---
+
+## 8. 이기종 연합 조회 — DuckDB
+
+서로 다른 연결의 테이블을 한 SELECT 로 조인한다.
+
+```sql
+SELECT a.code, b.name
+FROM   mysql_wms.wms.aaa a
+JOIN   postgre_mes.mes.k123.bbb b ON b.id = a.id
+```
+
+DuckDB 를 가운데 두고 각 연결을 카탈로그로 붙인 뒤(ATTACH) 한 문장으로 조인한다. 결과를
+파이썬으로 꺼내는 구간은 polars(Arrow → 행)가 맡는다.
+
+**사용자에게 DuckDB 를 보이지 않는다.** ATTACH·DSN·카탈로그 별칭은 전부 서버가 만들고, 사용자가
+아는 것은 「연결 관리」에 저장해 둔 이름뿐이다. DuckDB 자체 문법도 아니다 — DuckDB 는 3단계까지만
+알아서, 실행 전에 참조를 찾아 카탈로그 이름으로 **바꿔 쓴다**(`rewrite`).
+
+### 붙이는 순서가 곧 안전장치다
+
+1. 확장을 올린다 → 2. 카탈로그를 **READ_ONLY** 로 붙인다 → 3. `disabled_filesystems` 로 로컬 파일
+접근을 끊는다 → 4. 그제서야 사용자 SQL 을 돌린다.
+
+**거꾸로 할 수 없다.** `ATTACH` 도 파일 시스템 계층을 거치므로 먼저 잠그면 붙는 것 자체가 막히고,
+이 설정은 되돌릴 수도 없다. 그래서 카탈로그가 늘어날 때마다 허브를 새로 만들어 다시 한다.
+
+### 자격증명은 연결 문자열이 아니라 DuckDB 시크릿으로
+
+`CREATE SECRET` 을 만들고 `ATTACH '' … (SECRET …)` 으로 붙인다. 이유가 셋이다.
+
+1. **파싱 규칙이 확장마다 다르다.** MySQL 확장은 값의 따옴표를 벗기지 않고(`host='h'` → 호스트가
+   `'h'` 가 된다) 포트는 정수로 곧장 읽는다(`port='3306'` → `invalid stoi argument`).
+2. 그래서 **공백·따옴표가 든 비밀번호를 안전하게 실을 방법이 없다.**
+3. **실패 메시지에 자격증명이 안 실린다.** ATTACH 는 실패하면 연결 문자열을 그대로 에러에 담는다.
+
+지원은 **MySQL · PostgreSQL · SQL Server** 다. 기준은 "공식이냐"가 아니라 **`ATTACH` 를 등록하는
+확장이 있느냐**다. MongoDB 는 낄 수 없고, `odbc_scanner` 도 설치·로드는 되지만
+`ATTACH … (TYPE ODBC)` 를 등록하지 않아 카탈로그가 없다.
+
+---
+
+## 9. 두 층으로 갈라 두는 것들
+
+이 저장소에 반복해서 나오는 패턴이다. **"이 시스템은 무엇이 가능한가"(서버)와 "지금 나는 어떻게
+쓸 것인가"(브라우저)는 다른 질문**이므로 사는 곳을 갈라 둔다.
+
+| | 서버가 지키는 것 | 브라우저에 사는 것 |
+|---|---|---|
+| SQL 실행 | 연결의 **허용 명령**(`config.allowed_statements`) | 태그를 눌러 **잠시 끄기** |
+| 트랜잭션 | 연결의 `auto_commit` 기본값 | 툴바 토글(연결별 덮어쓰기) |
+| AI | 등록된 AI 연결과 그 모델 | **AI 기본 연결** · 패널의 모델사 칩 |
+
+브라우저 쪽은 **보안 경계가 아니다.** 서버에 두면 뜻이 달라진다 — 남이 켠 것을 내가 끄는 셈이
+되는데, 이건 남이 아니라 내 손을 막는 장치다.
+
+### 넓히는 방향으로 실패하지 않는다
+
+`allowed_statements` 가 없거나 깨져 있으면 `("select",)` 로 본다. 프런트의 기본값도 같아야 한다 —
+다르면 화면의 태그가 거짓말을 한다.
+
+### 선두 명령만 보면 놓친다
+
+`WITH d AS (DELETE FROM t RETURNING *) SELECT * FROM d` 는 선두가 `WITH` 라 읽기로 보이지만
+쓰기다. 그래서 선두 명령을 대조한 **뒤에** 문장 안에 남은 쓰기 키워드도 전부 확인한다.
+
+### 쓰기는 `read()` 로 태우면 안 된다
+
+`SqlConnector.read` 는 스트리밍 커서를 열고 **커밋하지 않는다.** UPDATE 를 그 경로로 보내면
+문장은 실행되는데 **그대로 사라진다.** 그래서 `execute` 를 따로 두고 `engine.begin()` 으로 감싼다.
+
+### 트랜잭션은 프로세스 메모리에 산다
+
+열린 트랜잭션은 **커넥션 하나를 붙잡은 채** 여러 HTTP 요청에 걸쳐 살아야 한다. 상태를 Redis 로
+옮겨도 **커넥션 자체는 옮길 수 없다.** api 프로세스를 늘리면 커밋 요청이 다른 프로세스로 갈 수
+있고, 그때는 **분명히 실패한다** — 조용히 새 트랜잭션을 열지 않는다. 지금 배포는 uvicorn 단일
+프로세스라 성립하며, 늘릴 때는 스티키 세션이 전제다.
+
+잊힌 트랜잭션은 **롤백**한다(커밋이 아니다). 사람이 누르지 않은 확정을 서버가 대신하면 되돌릴
+방법이 없다.
+
+---
+
+## 10. 임포트는 싸야 한다
+
+macOS 에서 Celery prefork 워커가 `fork()` 할 때 ObjC 런타임이 초기화 중이면 자식이 `SIGABRT` 로
+죽는다. 원인이 둘이었고 **둘 다 임포트 시점에 네이티브 작업을 하고 있었다.**
+
+1. `eai_connectors/__init__` 이 pyodbc·pymongo·boto3 를 전부 임포트 → PEP 562 지연 로딩으로 전환
+2. `auth/passwords.py` 가 임포트 시점에 Argon2 더미 해시를 계산 → 첫 사용 시로 미룸
+
+무거운 초기화를 모듈 최상위에 두면 fork 하는 순간 드러난다. Linux 컨테이너에서는 증상이 다르게
+나타날 뿐 문제 자체는 같다.
+
+---
+
+## 11. 새 것을 붙이는 법
+
+### 새 커넥터
+
+1. `apps/connectors/src/eai_connectors/<이름>.py` 에 `BaseConnector` 구현
+2. `registry.py` 에 지연 로더와 허용 키(`_<이름>_KEYS`) 등록
+3. 프런트 `CONNECTOR_SPECS` 에 필드 등록 — **키가 백엔드와 같아야 한다.** 다르면 `extra` 로 조용히 버려진다
+4. 단위 테스트 동반 (커넥터·노드는 예외 없음)
+
+### 새 노드 타입
+
+1. `eai_api.schemas.dag` 에 타입·파라미터 추가 (api·worker 공유 스펙)
+2. `apps/worker/src/eai_worker/nodes/` 에 실행기
+3. 캔버스 팔레트·`ConfigPanel` 에 UI
+4. **그릴 수 없어야 하는 연결이 있으면 `onConnect` 와 검증 양쪽에** 막는다
+
+### 양쪽에 있는 상수 — 한쪽만 고치면 어긋난다
+
+| 상수 | 백엔드 | 프런트 |
+|---|---|---|
+| `SQL_STATEMENTS` | `connection_service.py` | `api/statements.ts` |
+| `DUCK_TYPES` | `duck_service.py` | `canvas/duckRefs.ts` |
+| `SYNC_CHANNELS`·`SYNC_PURPOSES` | `schemas/dag.py` | `api/types.ts` |
+| 역할 계층 | `auth/rbac.py` 의 `_IMPLIES` | `auth.can()` |
+| 변수 치환 문법 | `schemas/variables.py` | `canvas/variables.ts` |
+
+한쪽만 늘리면 **화면에는 보이는데 저장·실행이 거부된다.**
+
+---
+
+## 12. 택하지 않은 것과 그 이유
+
+이 저장소에서 가장 값이 나가는 목록이다. 없는 기능은 대개 못 만든 것이 아니라 **안 만든 것**이다.
+
+| 안 한 것 | 이유 |
+|---|---|
+| 조인 노드 | 스트리밍(타깃 주도 풀) 모델과 맞추는 방법이 먼저다. 지금은 순차 concat |
+| 파이프라인 노드로서의 연합 조회 | 워커에도 DuckDB 를 넣어야 하고, 위와 같은 문제가 걸린다 |
+| 연합 조회의 쓰기 | 단일 SELECT/WITH 만 통과하고 ATTACH 는 전부 READ_ONLY |
+| SAP 를 타깃으로 | EAI 는 SAP 에서 읽어오는 방향이라 범위 밖 |
+| 동기화의 변환·컬럼 매핑 | 데이터가 워커를 지나지 않아 **구조상 불가능**. CDC 경로나 타깃 뷰로 |
+| 행 번호 참조 `${주문[1].id}` | SQL 은 `ORDER BY` 없이 순서를 보장하지 않는다. 첫 행과 전체로 충분 |
+| SAVEPOINT(부분 롤백) | 문장 이력이 필요하고, 그건 편집기가 아니라 마이그레이션 도구의 일 |
+| 실행 전 확인 대화상자 | 허용 명령이 이미 관문이다. 창을 하나 더 두면 그것부터 습관적으로 넘긴다 |
+| 파이프라인 탭 여러 개 동시 편집 | `useCanvasStore` 가 모듈 전역 싱글턴. 팩토리+Context 로 바꾸면 10개 파일이 함께 움직인다 |
+| 임베딩·RAG | 스키마 문맥은 메타DB 에서 직접 읽어 조립한다 — 검색이 아니라 조회다 |
+| OAuth2/OIDC IdP 연동 | 스키마(`users.external_id`)만 준비. 인증은 현재 JWT + RBAC |
+
+---
+
+## 13. 검증되지 않은 것
+
+문서가 조용히 넘어가면 안 되는 자리다.
+
+- **동기화(SymmetricDS)의 실환경 E2E** — 단위 테스트로만 검증했다. 트리거 기반이라 **운영 적용 전
+  부하 테스트가 게이트**이고, 부하 테스트는 운영에 쓸 라우팅 주기 그대로 재야 한다.
+- **실제 SAP 시스템** — 목 백엔드로만 확인했다. SNC(보안 네트워크 통신)도 미검증.
+- **MSSQL·MongoDB 실서버** — 단위 테스트만. 접근 가능한 인스턴스가 없었다.
+- **트랜잭션의 방언별 락 동작** — 의미는 SQLite 로 확인했다(커밋·롤백·read-your-writes).
+- **mypy(strict)** — src 기준 127건이 남아 CI 게이트가 아니다. 줄여 나가는 중.
+
+---
+
+## 14. 더 읽을 것
+
+| | |
+|---|---|
+| [README.md](../README.md) | 기동·사용법·화면 |
+| [CLAUDE.md](../CLAUDE.md) | 기능별 결정 근거의 전문(§14~§25) |
+| [CONTRIBUTING.md](../CONTRIBUTING.md) | 기여 절차 |
+| [docs/conventions/](conventions/) | 커밋·브랜치·머지 규칙 |
+| [demo/README.md](../demo/README.md) | 시연용 가상 DB |
+| [sync/symmetricds/README.md](../sync/symmetricds/README.md) | 동기화 운영 안내 |
+| `docs/EAI_아키텍처_설계문서.docx` · `.pdf` | 원본 기획 문서(부록) |


### PR DESCRIPTION
`.requirements/P2-문서와-시연.md` 의 **2-2 · 2-4 · 2-5** 세 항목이다. 이슈로는
[#45](https://github.com/SurvivorsStudio/ditter/issues/45) · [#48](https://github.com/SurvivorsStudio/ditter/issues/48) · [#44](https://github.com/SurvivorsStudio/ditter/issues/44).

## 변경 요약

### 1. `docs/ARCHITECTURE.md` 신설 (419줄) — #48

정식 설계 문서가 `docx`(671KB)·`pdf`(998KB) 뿐이라 **diff 도 리뷰도 되지 않았다.** 오픈소스
저장소에서는 약점이다. 원본은 「부록」으로 내리고 진실을 마크다운으로 옮겼다.

`CLAUDE.md` 를 통째로 복사하지 않았다 — 그쪽은 Claude Code 를 위한 구현 지침이라 성격이 다르다.
여기에는 이런 것을 담았다.

- **의존 방향** — api 는 worker 를 import 하지 않고, worker 는 `eai-api` 에 의존한다. DAG 스펙을
  양쪽이 공유하는 이유가 그것이다
- **실행 모델** — 타깃 주도 풀 스트리밍과 그 모델이 만드는 결과들(소스 앞에는 트리거만,
  팬아웃 스풀, 타깃 순차 실행, 워터마크 전진 순서)
- **커넥터 계약** — `BaseConnector` 시그니처, `ReadSpec` 의 `table｜query｜function`,
  새 커넥터·노드를 붙이는 법, 양쪽에 있는 상수 5쌍
- **택하지 않은 것과 그 이유** (11행) — 이 저장소에서 값이 가장 나가는 목록이다
- **검증되지 않은 것** (5행) — 문서가 조용히 넘어가면 안 되는 자리

본문의 파일 경로·상수·시그니처를 **전부 실제 코드와 대조**했다.

### 2. README 에 `demo/` 안내 — #45

루트 README 가 `demo/` 를 **한 번도 언급하지 않았다.** 쇼핑몰(MySQL)·WMS(MSSQL)·
고객센터(PostgreSQL) 세 DB 를 로컬에 띄우는 완성된 시연 스택인데 존재를 모르면 없는 것과 같다.

「빠른 시작」 뒤에 넣었다 — 기동을 마친 직후가 "이제 뭘 보지"가 되는 지점이다. **본체 스택을
먼저 띄워야 한다**는 전제도 함께 적었다(데모 DB 가 본체 네트워크에 올라탄다).

### 3. `CLAUDE.md` §12 개발 명령어 — #44

저장소에 남은 마지막 `pnpm` 두 줄을 npm 으로 고쳤다. 이슈는 pnpm 만 다뤘지만 **같은 절의
백엔드 명령도 실제와 어긋나 함께 고쳤다** — pnpm 만 고치면 처음 읽는 사람이 다음 줄에서
다시 막힌다.

- `pytest`·`ruff`·`mypy` 를 맨 이름으로 부르던 것 → `uv run --extra dev` 경유
  (셋 다 dev extra 라 `uv sync` 로는 설치되지 않는다)
- `mypy` 를 명령 목록에서 제외 — 127건이 남아 항상 실패한다
- `celery -A eai_worker.tasks` → `celery_app:app` + `-Q eai.default`
- 마이그레이션·스케줄러 누락 보완

## 테스트 방법

문서 전용이라 앱 테스트는 해당 없다. 대신 두 가지를 기계로 확인했다.

**링크·앵커 51건 전부 통과.** github-slugger 의 제거 코드포인트 범위를 그대로 옮긴 스크립트로
상대 경로·내부 앵커·교차 문서 앵커를 검사했다. (처음에 `·`(U+00B7)를 남기는 검사기를 썼다가
오탐이 났다 — 그 문자는 `¶-¹` 범위에 들어 제거된다.)

**본문 주장 ↔ 코드 대조.** 리뷰어가 31개 파일을 열어 의존 방향·실행 모델·`BaseConnector`
시그니처·상수 5쌍·마이그레이션 개수·「택하지 않은 것」 11행을 전부 확인했다.

## 관련 이슈

- #44 · #45 · #48 (이 PR)
- #66 — d1 다이어그램 정정. 이 PR 은 단서를 다는 데 그친다

## 코드리뷰

**이번 review 요약**: 1사이클(문서 전용이라 core path 아님). 발견 11건 → 확정 수정 6건(커밋 1),
이월 6건.

잡힌 결함 여섯 중 **넷이 같은 종류**였다 — 「문서 A 를 고쳤는데 그것을 가리키는 문서 B 가
따라오지 않은 것」. 가장 아팠던 것은 `README.md:19` 가 여전히 pdf 를 「상세 설계」로 가리키고
있던 것이다. 새 문서 링크는 「구조」 절 맨 끝에만 있어서, **이 PR 의 목적이 README 첫 화면에서
무효화되고 있었다.**

다이어그램 판단도 리뷰가 바꿨다. d2 는 단서 없이 실을 생각이었는데, `.dot` 원본이
`meta -> ws` 로 그려 놓은 것이 실제와 반대였다 — 진행률은 워커가 Redis Pub/Sub 로 publish 하고
API 의 WS 가 구독해 민다. **이벤트는 부가 채널이고 진실의 원천은 메타DB** 인데 그림이 그 둘을
뒤집었다. d3 는 SAP 상자에 `NW RFC SDK + ctypes` 를 수집 경로 안에 그려 놓아 §7 의 사이드카
격리와 정면으로 어긋나, **단서를 겹쳐 붙이는 대신 이 PR 에서 뺐다** — 단서가 달린 그림은
「검토된 그림」으로 보여 오히려 더 믿게 된다.

### 알려진 제약 사항 (이번 PR 미반영, 후속 검토 필요)

#### 1. README 로컬 개발 절도 venv 를 활성화하지 않은 채 맨 이름으로 부른다

- **위치**: `README.md:157`
- **문제**: `uv venv` 로 환경만 만들고 활성화 없이 `alembic`·`uvicorn`·`celery` 를 맨 이름으로
  부른다. `CLAUDE.md` §12 가 이번에 고쳐진 바로 그 함정이다.
- **왜 이번 PR 에 안 넣었나**: #44 의 범위 밖이다. 지금은 두 문서가 같은 일을 다른 형태로
  적고 있고, **그 사실 자체는 §12 에 인용 블록으로 적어 두었다.**

#### 2. `d3_ingestion.dot` 의 SAP 상자가 SDK 를 수집 경로에 그린다

- **위치**: `docs/diagrams/d3_ingestion.dot`
- **문제**: 문서에서는 뺐지만 `.dot`·`.png` 는 남아 있고, 그 안의 `NW RFC SDK + ctypes` 는
  사이드카 격리와 반대다(실제도 ctypes 가 아니라 사이드카의 pyrfc).
- **왜 이번 PR 에 안 넣었나**: 그림 수정은 별도 작업이다 — [#86](https://github.com/SurvivorsStudio/ditter/issues/86) 으로 열었다 (d2 의 이벤트 경로와 함께).

#### 3. mypy 잔여 127건이 네 곳에 박혀 있다

- **위치**: `docs/ARCHITECTURE.md:412` (외 `ci.yml`·`README`·`CLAUDE.md` §12)
- **문제**: 줄여 나가는 중인 숫자를 네 곳에 두면 반드시 어긋나고, 하나만 갱신하면 나머지
  셋이 거짓말을 한다. `마이그레이션 7개` 도 같은 성격이다.
- **왜 이번 PR 에 안 넣었나**: 단일 출처를 어디로 할지가 판단이고, 숫자가 현재도 맞는지
  확인하지 못했다.

#### 4. CONTRIBUTING 과 ARCHITECTURE §11 에 같은 상수 표가 두 벌 있다

- **위치**: `CONTRIBUTING.md:92`
- **문제**: `CONTRIBUTING.md:4` 가 「각 항목이 가리키는 문서가 단일 출처」라고 선언해 놓고
  5행짜리 표를 복제했다. **그 표가 경고하는 사고가 문서에서 나게 된다.**
- **왜 이번 PR 에 안 넣었나**: 표를 지우는 판단은 문서 소유자 몫이다.

#### 5. CONTRIBUTING 이 여전히 CLAUDE.md 를 첫 읽을거리로 민다

- **위치**: `CONTRIBUTING.md:17`
- **문제**: 표에서 「어떻게 짜여 있나」를 ARCHITECTURE.md 로 옮겼는데, 바로 아래 문단은
  「**CLAUDE.md 를 권한다**」로 시작한다.
- **왜 이번 PR 에 안 넣었나**: 문장 톤 판단이라 임의로 손대지 않았다.

#### 6. README·CLAUDE.md 의 커넥터 목록이 6종이다 (실제 10종)

- **위치**: `README.md:288`
- **문제**: 실제는 10종이고 `ARCHITECTURE.md` §4 표는 10종을 맞게 적는다. **AI 를 커넥터로
  다룬다는 것이 README 서두의 핵심 주장인데 정작 구조 블록에 그 커넥터가 없다.**
- **왜 이번 PR 에 안 넣었나**: 이번 변경 밖의 줄이고 ARCHITECTURE 쪽이 맞아 급하지 않다.
