### PR TITLE
fix(web): pyLiteral 이 제어문자를 이스케이프하게 한다

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,7 @@
 | CDC | Debezium (Kafka Connect), Apache Kafka |
 | 메타데이터 | PostgreSQL 16 |
 | 커넥터 드라이버 | PyMySQL, psycopg3, pyodbc, PyMongo, NW RFC SDK, boto3 |
+| AI 모델 (커넥터로 취급) | Gemini · AWS Bedrock · **Ollama**(로컬 오픈웨이트, 상용 API 없이 — §23) |
 | 인프라 | Docker, Docker Compose, AWS EC2 / ALB / RDS / S3 / ECR / CloudWatch |
 | 품질 | pytest, ruff, mypy (백엔드) · vitest, eslint, prettier (프론트) |
 
@@ -76,9 +77,11 @@ eai-platform/
 │   ├── connectors/                # 공통 커넥터 라이브러리 (api·worker 공유)
 │   │   └── src/eai_connectors/
 │   │       ├── base.py            # BaseConnector 프로토콜
+│   │       ├── registry.py        # 종류 → 구현 지연 로딩 (임포트는 싸야 한다 — §15)
 │   │       ├── mysql.py  postgres.py  mssql.py  mongo.py
-│   │       ├── sap_rfc.py         # 전용 컨테이너에서 실행
-│   │       └── s3.py
+│   │       ├── sap_rfc.py         # 사이드카 HTTP 게이트웨이 (SDK 는 여기 없다 — §16)
+│   │       ├── s3.py  local_file.py
+│   │       └── gemini.py  bedrock.py  ollama.py   # AI 모델도 커넥터다 (§23)
 │   ├── sap-connector/             # SAP RFC 전용 컨테이너 (NW RFC SDK 포함)
 │   └── web/                       # React + React Flow 프론트엔드
 │       ├── src/

--- a/README.md
+++ b/README.md
@@ -274,7 +274,9 @@ MSSQL 커넥터 테스트는 `pyodbc` 가 필요하다. macOS 에서 `libodbc` �
 
 ```
 apps/
-  connectors/   BaseConnector 계약 + MySQL·PostgreSQL·MSSQL·MongoDB·SAP·S3·로컬파일 (지연 로딩)
+  connectors/   BaseConnector 계약 — 데이터 10종 중 소스/타깃 7종
+                (MySQL·PostgreSQL·MSSQL·MongoDB·SAP RFC·S3·로컬파일)
+                + AI 모델 3종 (Gemini·Bedrock·Ollama) — 지연 로딩
   api/          FastAPI(REST/WS) + FastMCP, 모델·Alembic, 인증(JWT/RBAC), 서비스 계층, 운영 CLI
   worker/       Celery 워커 — DAG 엔진, 노드 실행기(Python 격리 샌드박스 포함), 팬아웃 스풀,
                 Cron 스케줄러, CDC Sink Worker

--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ MSSQL 커넥터 테스트는 `pyodbc` 가 필요하다. macOS 에서 `libodbc` �
 
 ```
 apps/
-  connectors/   BaseConnector 계약 — 데이터 10종 중 소스/타깃 7종
+  connectors/   BaseConnector 계약 — 커넥터 10종 · 소스/타깃 7종
                 (MySQL·PostgreSQL·MSSQL·MongoDB·SAP RFC·S3·로컬파일)
                 + AI 모델 3종 (Gemini·Bedrock·Ollama) — 지연 로딩
   api/          FastAPI(REST/WS) + FastMCP, 모델·Alembic, 인증(JWT/RBAC), 서비스 계층, 운영 CLI

--- a/apps/api/tests/test_docs_connector_list.py
+++ b/apps/api/tests/test_docs_connector_list.py
@@ -37,23 +37,66 @@ _ALIASES: dict[ConnectorType, tuple[str, ...]] = {
 
 _FENCE = re.compile(r"^```.*?^```", re.M | re.S)
 
+#: 구조 트리에서의 **디렉터리 엔트리** `connectors/`.
+#:
+#: 그냥 부분문자열로 찾으면 경로 한복판(`apps/connectors/src/eai_connectors/base.py`)도
+#: 걸려 CLAUDE.md 의 §5 코드블록이 후보로 딸려 온다. 우리가 찾는 것은 "connectors 라는
+#: 디렉터리를 나열한 줄"이므로 뒤에 공백이나 줄끝이 와야 한다.
+_CONNECTORS_ENTRY = re.compile(r"connectors/(?=\s|$)", re.M)
+
+
+#: ARCHITECTURE 에서 표를 찾는 닻. 실패 메시지에도 그대로 실어 무엇을 찾다 실패했는지 보인다.
+_ARCH_HEADING = "### 지금 있는 커넥터"
+
+
+def _block_head(block: str) -> str:
+    """실패 메시지에서 블록을 가리킬 한 줄 — 펜스 다음의 첫 내용 줄(트리 루트)."""
+    for line in block.splitlines()[1:]:
+        if line.strip():
+            return line.strip()
+    return "(빈 블록)"
+
 
 def _structure_block(text: str) -> str:
-    """커넥터 목록이 든 구조 트리(펜스 코드블록)만 떼어 낸다."""
-    for block in _FENCE.findall(text):
-        if "connectors/" in block:
-            return block
+    """커넥터 목록이 든 구조 트리(펜스 코드블록)만 떼어 낸다.
+
+    후보가 여럿이면 **고르지 않고 세운다.** 첫 번째를 집으면 문서에 코드블록 하나가
+    끼어드는 것만으로 검사 대상이 조용히 옮겨가고, 그때 나오는 말은 "커넥터가 하나도
+    없다"라 멀쩡한 문서를 의심하게 된다 — 조용히 다른 것을 집는 쪽이 언제나 더 나쁘다.
+    """
+    blocks = [block for block in _FENCE.findall(text) if _CONNECTORS_ENTRY.search(block)]
+    if len(blocks) == 1:
+        return blocks[0]
+    if not blocks:
+        raise AssertionError(
+            "구조 트리에서 `connectors/` 를 찾지 못했다. 트리가 옮겨졌거나 사라졌다 — "
+            "이 테스트가 무엇을 검사하는지부터 다시 정해야 한다."
+        )
+    heads = " · ".join(_block_head(block) for block in blocks)
     raise AssertionError(
-        "구조 트리에서 `connectors/` 를 찾지 못했다. 트리가 옮겨졌거나 사라졌다 — "
-        "이 테스트가 무엇을 검사하는지부터 다시 정해야 한다."
+        f"`connectors/` 를 담은 펜스 블록이 {len(blocks)}개다 — 어느 쪽이 구조 트리인지 "
+        f"정할 수 없다. 각 블록의 첫 줄: {heads}. "
+        "문서가 거짓말을 하는 것이 아니라 이 테스트가 대상을 못 고르는 것이다 — "
+        "검사할 블록을 하나로 좁히거나 고르는 기준을 다시 정해야 한다."
     )
 
 
 def _architecture_table(text: str) -> str:
-    """ARCHITECTURE 의 「지금 있는 커넥터」 표. 다음 제목 앞에서 끊는다."""
-    start = text.index("### 지금 있는 커넥터")
-    end = text.index("\n#", start + 1)
-    return text[start:end]
+    """ARCHITECTURE 의 「지금 있는 커넥터」 표. 다음 제목 앞에서 끊는다.
+
+    `_structure_block` 과 **같은 결로** 실패한다. `str.index` 로 두면 제목만 바꾼 PR 에서
+    `ValueError: substring not found` 하나만 남아, 문서를 고친 사람이 왜 백엔드 테스트가
+    깨졌는지부터 찾아야 한다.
+    """
+    start = text.find(_ARCH_HEADING)
+    if start < 0:
+        raise AssertionError(
+            f"「{_ARCH_HEADING}」 를 찾지 못했다. 표가 옮겨졌거나 제목이 바뀌었다 — "
+            "이 테스트가 무엇을 검사하는지부터 다시 정해야 한다."
+        )
+    end = text.find("\n#", start + 1)
+    # 그 절이 문서 마지막이면 다음 제목이 없다 — 그때는 끝까지가 곧 그 절이다.
+    return text[start:] if end < 0 else text[start:end]
 
 
 _SECTIONS = {

--- a/apps/api/tests/test_docs_connector_list.py
+++ b/apps/api/tests/test_docs_connector_list.py
@@ -1,0 +1,78 @@
+"""문서의 **커넥터 목록**이 실제 ``ConnectorType`` 과 어긋나지 않게 한다.
+
+README·CLAUDE.md 의 구조 트리가 커넥터를 6종에 멈춰 둔 것을 뒤늦게 발견했다. 실제는
+10종이었고, 특히 **AI 를 커넥터로 다룬다는 것이 README 서두의 핵심 주장인데 정작 구조
+블록에는 그 커넥터가 없었다.**
+
+검사 범위를 「문서 어딘가」가 아니라 **그 목록 자리**로 좁히는 것이 이 파일의 요점이다.
+파일 전체를 훑으면 AI 커넥터 이름이 다른 절(README 「AI 모델」)에 있어 **고치기 전에도
+통과한다** — 실제로 그렇게 짰다가 통과하는 것을 보고 다시 썼다. 통과만 보고 넘어갔으면
+커버리지를 주장만 하는 테스트가 남을 뻔했다.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+from eai_connectors.base import ConnectorType
+
+_REPO = Path(__file__).resolve().parents[3]
+
+#: 커넥터 종류 → 목록에 나와야 하는 표기(하나라도 맞으면 통과).
+#: 사람이 읽는 글이라 ``sap_rfc`` 대신 「SAP RFC」로 쓰는 편이 자연스럽다.
+_ALIASES: dict[ConnectorType, tuple[str, ...]] = {
+    ConnectorType.MYSQL: ("MySQL", "mysql"),
+    ConnectorType.POSTGRES: ("PostgreSQL", "postgres"),
+    ConnectorType.MSSQL: ("MSSQL", "SQL Server", "mssql"),
+    ConnectorType.MONGO: ("MongoDB", "mongo"),
+    ConnectorType.SAP_RFC: ("SAP RFC", "SAP", "sap_rfc"),
+    ConnectorType.S3: ("S3", "s3"),
+    ConnectorType.LOCAL_FILE: ("로컬파일", "로컬 파일", "local_file"),
+    ConnectorType.GEMINI: ("Gemini", "gemini"),
+    ConnectorType.BEDROCK: ("Bedrock", "bedrock"),
+    ConnectorType.OLLAMA: ("Ollama", "ollama"),
+}
+
+_FENCE = re.compile(r"^```.*?^```", re.M | re.S)
+
+
+def _structure_block(text: str) -> str:
+    """커넥터 목록이 든 구조 트리(펜스 코드블록)만 떼어 낸다."""
+    for block in _FENCE.findall(text):
+        if "connectors/" in block:
+            return block
+    raise AssertionError(
+        "구조 트리에서 `connectors/` 를 찾지 못했다. 트리가 옮겨졌거나 사라졌다 — "
+        "이 테스트가 무엇을 검사하는지부터 다시 정해야 한다."
+    )
+
+
+def _architecture_table(text: str) -> str:
+    """ARCHITECTURE 의 「지금 있는 커넥터」 표. 다음 제목 앞에서 끊는다."""
+    start = text.index("### 지금 있는 커넥터")
+    end = text.index("\n#", start + 1)
+    return text[start:end]
+
+
+_SECTIONS = {
+    "README.md": _structure_block,
+    "CLAUDE.md": _structure_block,
+    "docs/ARCHITECTURE.md": _architecture_table,
+}
+
+
+def test_alias_table_covers_every_connector_type() -> None:
+    """새 커넥터를 만들면 여기부터 걸린다 — 그다음이 문서다."""
+    assert set(_ALIASES) == set(ConnectorType)
+
+
+@pytest.mark.parametrize("doc", sorted(_SECTIONS))
+def test_connector_list_matches_reality(doc: str) -> None:
+    section = _SECTIONS[doc]((_REPO / doc).read_text(encoding="utf-8"))
+    missing = [k.value for k, names in _ALIASES.items() if not any(n in section for n in names)]
+    assert not missing, (
+        f"{doc} 의 커넥터 목록에 없는 것: {missing}. "
+        "커넥터를 늘렸으면 문서의 목록도 함께 늘린다 — 한쪽만 고치면 문서가 거짓말을 한다."
+    )

--- a/apps/api/tests/test_variables.py
+++ b/apps/api/tests/test_variables.py
@@ -377,3 +377,58 @@ class TestPythonContext:
     def test_sql_context_is_unchanged(self) -> None:
         out = substitute_params({"where": "id IN (${주문.id[]})"}, {"주문.id[]": [1, 2]})
         assert out["where"] == "id IN (1, 2)"
+
+
+class TestPythonControlChars:
+    """제어문자가 든 값도 유효한 Python 리터럴이 되어야 한다.
+
+    프런트 `canvas/variables.test.ts` 의 「제어문자」 사례와 **같은 값·같은 기대치**다.
+    한쪽만 고치면 "편집기에서는 되는데 실행하면 다르다"가 나므로 양쪽이 함께 깨져야 한다
+    (`variables.ts` 머리말의 전제).
+    """
+
+    def code(self, source: str, values: dict[str, object]) -> str:
+        return substitute_params({"code": source}, values)["code"]
+
+    def test_newline_is_escaped(self) -> None:
+        """따옴표 하나짜리 리터럴은 실제 줄바꿈을 담을 수 없다 — SyntaxError 다."""
+        out = self.code("N = [${주문.memo[]}]", {"주문.memo[]": ["a\nb"]})
+        assert out == "N = ['a\\nb']"
+        assert ast.literal_eval(out.split("= ")[1]) == ["a\nb"]
+
+    def test_carriage_return_and_tab(self) -> None:
+        assert self.code("N = [${주문.memo[]}]", {"주문.memo[]": ["line1\r\nline2"]}) == (
+            "N = ['line1\\r\\nline2']"
+        )
+        assert self.code("N = [${주문.memo[]}]", {"주문.memo[]": ["a\tb"]}) == "N = ['a\\tb']"
+
+    def test_unnamed_control_chars_use_hex(self) -> None:
+        """NUL 은 Python 소스에 아예 못 들어간다 — 이스케이프가 유일한 길이다."""
+        assert self.code("N = [${주문.memo[]}]", {"주문.memo[]": ["a\x00b"]}) == "N = ['a\\x00b']"
+        assert self.code("N = [${주문.memo[]}]", {"주문.memo[]": ["a\x1bb"]}) == "N = ['a\\x1bb']"
+
+    def test_backslash_is_doubled(self) -> None:
+        assert self.code("N = [${주문.p[]}]", {"주문.p[]": ["C:\\path"]}) == "N = ['C:\\\\path']"
+        # 값이 이미 `\n` 두 글자면 그대로 두 글자여야 한다 (줄바꿈으로 오해하지 않는다)
+        assert self.code("N = [${주문.p[]}]", {"주문.p[]": ["a\\nb"]}) == "N = ['a\\\\nb']"
+
+    def test_both_quote_kinds(self) -> None:
+        out = self.code("N = [${주문.t[]}]", {"주문.t[]": ["has \"dq\" and 'sq'"]})
+        assert out == """N = ['has "dq" and \\'sq\\'']"""
+        assert ast.literal_eval(out.split("= ")[1]) == ["has \"dq\" and 'sq'"]
+
+    def test_nonascii_invisible_differs_from_front_but_evaluates_the_same(self) -> None:
+        """**여기서 양쪽 표기가 갈린다** — 알고 두는 것이지 버그가 아니다.
+
+        `repr` 은 비ASCII 비출력 문자를 ``\\u200b`` 로 쓰지만 프런트는 원문 그대로 둔다.
+        그 글자는 리터럴 안에 그냥 있어도 유효한 Python 이라 **값은 같다.** 글자까지 맞추려면
+        유니코드 printable 표를 프런트에 복제해야 하는데, 그것이야말로 이 파일이 경계하는
+        「양쪽이 어긋난다」를 하나 더 만드는 일이다.
+
+        프런트의 같은 사례: `canvas/variables.test.ts` 의 「비ASCII 비출력 문자」.
+        """
+        out = self.code("N = [${주문.z[]}]", {"주문.z[]": ["a\u200bb"]})
+        assert out == "N = ['a\\u200bb']"          # 백엔드는 이스케이프한다
+        assert ast.literal_eval(out.split("= ")[1]) == ["a\u200bb"]
+        # 프런트가 내는 원문 그대로도 같은 값으로 읽힌다 — 그래서 안전하다
+        assert ast.literal_eval("['a\u200bb']") == ["a\u200bb"]

--- a/apps/web/src/canvas/variables.test.ts
+++ b/apps/web/src/canvas/variables.test.ts
@@ -330,6 +330,45 @@ describe('Python 코드 문맥 (transform.python 의 code)', () => {
     expect(code('dt = "${주문.dt}"', { '주문.dt': '2026-08-01' })).toBe('dt = "2026-08-01"')
   })
 
+  // ── 제어문자 ────────────────────────────────────────────────────────────
+  // 백엔드 `tests/test_variables.py` 의 `TestPythonControlChars` 와 **같은 사례**다.
+  // 한쪽만 고치면 "편집기에서는 되는데 실행하면 다르다"가 나므로 양쪽이 함께 깨져야 한다.
+
+  it('줄바꿈을 이스케이프한다 — 안 하면 Python SyntaxError 다', () => {
+    expect(code('N = [${주문.memo[]}]', { '주문.memo[]': ['a\nb'] })).toBe("N = ['a\\nb']")
+  })
+
+  it('캐리지리턴·탭도 repr 과 같은 이름으로', () => {
+    expect(code('N = [${주문.memo[]}]', { '주문.memo[]': ['line1\r\nline2'] })).toBe(
+      "N = ['line1\\r\\nline2']",
+    )
+    expect(code('N = [${주문.memo[]}]', { '주문.memo[]': ['a\tb'] })).toBe("N = ['a\\tb']")
+  })
+
+  it('이름 없는 제어문자는 \\xNN 으로 — NUL 은 Python 소스에 아예 못 들어간다', () => {
+    expect(code('N = [${주문.memo[]}]', { '주문.memo[]': ['a\u0000b'] })).toBe("N = ['a\\x00b']")
+    expect(code('N = [${주문.memo[]}]', { '주문.memo[]': ['a\u001bb'] })).toBe("N = ['a\\x1bb']")
+  })
+
+  it('역슬래시는 두 개로 — 이스케이프가 겹쳐도 어긋나지 않는다', () => {
+    expect(code('N = [${주문.p[]}]', { '주문.p[]': ['C:\\path'] })).toBe("N = ['C:\\\\path']")
+    // 값이 이미 `\n` 두 글자면 그대로 두 글자여야 한다 (줄바꿈으로 오해하지 않는다)
+    expect(code('N = [${주문.p[]}]', { '주문.p[]': ['a\\nb'] })).toBe("N = ['a\\\\nb']")
+  })
+
+  it('따옴표가 둘 다 있으면 작은따옴표로 감싸고 안쪽을 이스케이프한다', () => {
+    expect(code('N = [${주문.t[]}]', { '주문.t[]': ['has "dq" and \'sq\''] })).toBe(
+      'N = [\'has "dq" and \\\'sq\\\'\']',
+    )
+  })
+
+  it('비ASCII 비출력 문자는 원문 그대로 — 백엔드와 표기가 갈리는 유일한 자리다', () => {
+    // 백엔드 `repr` 은 이것을 `\\u200b` 로 쓴다. 값은 같고 표기만 다르며, 원문 그대로도
+    // 유효한 Python 이다. 백엔드의 같은 사례:
+    // `test_nonascii_invisible_differs_from_front_but_evaluates_the_same`
+    expect(code('N = [${주문.z[]}]', { '주문.z[]': ['a\u200bb'] })).toBe("N = ['a\u200bb']")
+  })
+
   it('SQL 문맥은 그대로다', () => {
     expect(substitute('id IN (${주문.id[]})', { '주문.id[]': [1, 2] }, { contextKey: 'where' })).toBe(
       'id IN (1, 2)',

--- a/apps/web/src/canvas/variables.ts
+++ b/apps/web/src/canvas/variables.ts
@@ -226,15 +226,42 @@ export function renderList(
     .join(', ')
 }
 
-/** Python 리터럴 표기. 백엔드 `_py_literal` 과 짝 — 따옴표·역슬래시를 이스케이프한다. */
+/** `repr` 이 이름 있는 이스케이프를 주는 셋. 나머지 제어문자는 `\xNN` 이 된다. */
+const PY_NAMED_ESCAPES: Record<string, string> = { '\t': '\\t', '\n': '\\n', '\r': '\\r' }
+
+/**
+ * 따옴표 안에 들어갈 몸통을 이스케이프한다 (감싸는 따옴표는 호출자가 붙인다).
+ *
+ * **줄바꿈을 빠뜨리면 안 된다.** Python 의 따옴표 하나짜리 문자열 리터럴은 실제 줄바꿈을
+ * 담을 수 없어 `SyntaxError` 가 되고, NUL 은 아예 소스에 들어갈 수 없다
+ * ("source code string cannot contain null bytes").
+ */
+function pyEscapeBody(text: string): string {
+  // eslint-disable-next-line no-control-regex -- 제어문자를 이스케이프하는 것이 이 함수의 일이다
+  return text.replace(/[\\\u0000-\u001f\u007f]/g, (ch) =>
+    ch === '\\'
+      ? '\\\\'
+      : (PY_NAMED_ESCAPES[ch] ?? `\\x${ch.charCodeAt(0).toString(16).padStart(2, '0')}`),
+  )
+}
+
+/**
+ * Python 리터럴 표기. 백엔드 `_py_literal`(= `repr`) 과 짝이다.
+ *
+ * ASCII 입력에서는 `repr` 과 **글자까지 같은** 결과를 낸다. 비ASCII 비출력 문자
+ * (U+200B 같은 것)는 `repr` 이 `\u200b` 로 쓰지만 여기서는 원문 그대로 둔다 — 그 글자는
+ * 리터럴 안에 그냥 있어도 유효한 Python 이라 **값은 같고 표기만 다르다.** 완전한 일치는
+ * 유니코드 printable 표가 있어야 하는데, 그 표를 프런트에 복제하면 이 파일이 경계하는
+ * 「양쪽이 어긋난다」를 하나 더 만드는 셈이다.
+ */
 function pyLiteral(value: unknown): string {
   if (value === null || value === undefined) return 'None'
   if (typeof value === 'boolean') return value ? 'True' : 'False'
   if (typeof value === 'number') return String(value)
-  // repr 과 같은 결과를 낸다: 작은따옴표가 들어 있으면 큰따옴표로 감싼다
+  // repr 과 같은 규칙: 작은따옴표가 들어 있고 큰따옴표가 없을 때만 큰따옴표로 감싼다
   const text = String(value)
-  if (text.includes("'") && !text.includes('"')) return `"${text.replace(/\\/g, '\\\\')}"`
-  return `'${text.replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'`
+  if (text.includes("'") && !text.includes('"')) return `"${pyEscapeBody(text)}"`
+  return `'${pyEscapeBody(text).replace(/'/g, "\\'")}'`
 }
 
 /** 참조됐지만 값이 없는 변수 */

--- a/apps/web/src/canvas/variables.ts
+++ b/apps/web/src/canvas/variables.ts
@@ -248,11 +248,16 @@ function pyEscapeBody(text: string): string {
 /**
  * Python 리터럴 표기. 백엔드 `_py_literal`(= `repr`) 과 짝이다.
  *
- * ASCII 입력에서는 `repr` 과 **글자까지 같은** 결과를 낸다. 비ASCII 비출력 문자
- * (U+200B 같은 것)는 `repr` 이 `\u200b` 로 쓰지만 여기서는 원문 그대로 둔다 — 그 글자는
- * 리터럴 안에 그냥 있어도 유효한 Python 이라 **값은 같고 표기만 다르다.** 완전한 일치는
- * 유니코드 printable 표가 있어야 하는데, 그 표를 프런트에 복제하면 이 파일이 경계하는
- * 「양쪽이 어긋난다」를 하나 더 만드는 셈이다.
+ * ASCII 입력에서는 `repr` 과 **글자까지 같은** 결과를 낸다 (0x00-0x7f 전수 대조 확인).
+ *
+ * 갈리는 것은 **`str.isprintable()` 이 거짓인 비ASCII 전부**다 — U+200B 하나가 아니라
+ * BMP 에서만 약 7,900자이고, 유니코드 카테고리 Cc·Cf·Cn·Co·Zl·Zp·Zs 가 그 범위다
+ * (U+0085·U+00A0·U+2028·U+FEFF…). `repr` 은 이것들을 `\x85`·`\u2028` 처럼 이스케이프하고
+ * 여기서는 원문 그대로 둔다. 전수 대조에서 **전부 유효한 Python 으로 컴파일되고 값도
+ * 같았다** — 표기만 다르다. 완전한 일치는 유니코드 printable 표가 있어야 하는데, 그 표를
+ * 프런트에 복제하면 이 파일이 경계하는 「양쪽이 어긋난다」를 하나 더 만드는 셈이다.
+ *
+ * 짝 없는 대리 문자(U+D800-U+DFFF)와 숫자 표기는 아직 갈린다 — 별도 이슈.
  */
 function pyLiteral(value: unknown): string {
   if (value === null || value === undefined) return 'None'


### PR DESCRIPTION
[#46](https://github.com/SurvivorsStudio/ditter/issues/46) 과, PR [#85](https://github.com/SurvivorsStudio/ditter/pull/85) 리뷰에서 이월된 커넥터 목록 불일치를 함께 처리한다.

## 1. `pyLiteral` 이 제어문자를 이스케이프하게 한다 — #46

`apps/web/src/canvas/variables.ts` 의 `pyLiteral` 은 따옴표·역슬래시만 이스케이프하고
**줄바꿈을 그대로 두었다.** 백엔드 쌍둥이(`schemas/variables.py._py_literal`)는 같은 자리에서
Python `repr` 을 쓴다.

값이 `"a\nb"` 일 때:

| | 결과 | 유효한가 |
|---|---|---|
| 백엔드 | `'a\nb'` | ✅ |
| 프런트 | 작은따옴표 안에 **실제 줄바꿈** | ❌ Python `SyntaxError` |

`\t`·`\n`·`\r` 은 이름 있는 이스케이프로, 나머지 C0 와 DEL 은 `\xNN` 으로 쓴다. NUL 은
특히 그렇다 — Python 소스에 아예 들어갈 수 없다(*source code string cannot contain null bytes*).

### 양쪽 테스트에 같은 사례를 넣는다 — 이게 이슈의 핵심이었다

`variables.ts` 머리말이 이 파일의 전제를 못박고 있다.

> 한쪽만 고치면 "편집기에서는 되는데 실행하면 다르다"가 나므로,
> **양쪽 테스트에 같은 사례**를 넣어 함께 깨지게 했다.

그런데 **어느 쪽에도 줄바꿈이 든 값 사례가 없었다.** 그래서 이 어긋남을 아무도 잡지 못했다.
프런트 `variables.test.ts` 와 백엔드 `TestPythonControlChars` 에 **같은 값·같은 기대치**를
넣었다 — 줄바꿈 · CR · 탭 · NUL · ESC · 역슬래시 · 두 종류 따옴표.

## 2. 커넥터 목록을 실제 10종으로 — PR #85 이월

README 구조 블록과 CLAUDE.md §3 트리가 **6종에 멈춰 있었다.** 실제 `ConnectorType` 은 10종이고
로컬파일과 AI 3종(Gemini·Bedrock·Ollama)이 빠져 있었다.

**AI 를 커넥터로 다룬다는 것이 README 서두의 핵심 주장인데 정작 구조 블록에 그 커넥터가
없었다** — 읽는 사람이 그 주장을 확인할 자리가 문서 안에 없다.

사람이 세는 한 또 어긋나므로 `test_docs_connector_list.py` 로 CI 가 잡게 했다.

## 테스트 방법

```
apps/api   pytest 542 passed · ruff All checks passed
apps/web   vitest 288 passed (13 파일) · eslint 통과 · npm run build ✓
```

### 전수·퍼즈로 `repr` 과 대조했다

리뷰 과정에서 `vite-node` 로 실제 `substitute` 를 태우고 같은 값을 백엔드에 태워
**코드포인트 단위로** 비교했다.

| 실험 | 결과 |
|---|---|
| BMP 전수 63,488자 (`'a'+ch+'b'`) | **ASCII 구간 불일치 0건** — `repr` 과 글자까지 같다 |
| 같은 실험, 비ASCII | 7,947건 표기 차이 — **정확히 `str.isprintable()` 의 여집합** |
| 그 7,947건을 `compile`+`exec` | **전부 성공, 값도 전부 일치** |
| 퍼즈 2만건 (따옴표·역슬래시·제어문자 조합) | **불일치 0건** |

비ASCII 차이는 **알고 두는 것**이다. 그 글자들은 리터럴 안에 그냥 있어도 유효한 Python 이라
값은 같고 표기만 다르다. 글자까지 맞추려면 유니코드 printable 표를 프런트에 복제해야 하는데,
그것이야말로 이 파일이 경계하는 「양쪽이 어긋난다」를 하나 더 만드는 일이다. 양쪽 주석·테스트가
이 사실을 서로 가리키며 못박는다.

### `SENTINEL` 과 부딪히지 않는다

`variables.ts` 는 `'\x00EAI_DOLLAR\x00'` 을 센티널로 쓴다. 확인해 보니 이번 수정이 오히려
**python 문맥의 구멍 하나를 막았다** — 값 안의 raw NUL 이 이제 `\x00` 네 글자가 되어 언마스킹
단계에서 센티널로 오인될 여지가 사라진다.

## 관련 이슈

- #46 (이 PR 로 닫힌다)
- #87 — 남은 두 축(짝 없는 대리 문자 · 숫자 표기)

## 코드리뷰

**이번 review 요약**: 1사이클. 발견 8건 → 확정 수정 3건(커밋 3), 이월 2건.

리뷰가 전수·퍼즈로 다시 재서 **내가 주장한 범위가 과소하다는 것**을 밝혔다 — 주석에 「U+200B
같은 것」이라고 썼는데 실제로는 `isprintable()` 여집합 전부(약 7,900자)다. 주석을 고쳤다.

그리고 리뷰어가 **자기 제안의 결함을 스스로 잡았다.** "펜스 블록이 정확히 하나여야 한다"를
그대로 넣으면 CLAUDE.md 후보가 2개라 지금 당장 빨개진다. 조건을 하나 더 얹는 대신
**술어를 날카롭게** 했다 — `"connectors/" in block` 은 경로 한복판
(`apps/connectors/src/...`)도 잡지만, 찾는 것은 **디렉터리 엔트리**이므로 뒤에 공백이나 줄끝이
와야 한다. 조건은 여전히 하나이고 후보가 문서마다 1개로 떨어진다.

### 이 테스트는 한 번 무의미했다가 되살아났다

처음엔 파일 전체를 훑게 짰는데 **고치기 전 문서도 통과했다** — AI 커넥터 이름이 README 의
다른 절에 있었기 때문이다. 통과만 보고 넘어갔으면 커버리지를 주장만 하는 테스트가 남을 뻔했다.
지금 형태는 고치기 전 문서를 넣으면 README 3종 · CLAUDE.md 4종을 누락으로 보고한다(확인함).
그 경위를 파일 도크스트링에 남겼다.

새로 넣은 실패 경로(후보 0개 · 후보 2개 · 제목 없음 · 절이 파일 마지막)도 인위적으로 만들어
**실제로 그 메시지가 나오는지** 확인했다. 안내를 달아 놓고 도달하지 않으면 없는 것과 같다.

### 알려진 제약 사항 (이번 PR 미반영, 후속 검토 필요)

두 항목 모두 [#87](https://github.com/SurvivorsStudio/ditter/issues/87) 에 있다.

#### 1. 짝 없는 대리 문자에서 프런트 결과가 Python 으로 성립하지 않는다

- **위치**: `apps/web/src/canvas/variables.ts:240`
- **문제**: 전수 검사에서 **유일하게** 프런트 출력이 Python 으로 성립하지 않은 경우다.
  그 문자열은 UTF-8 인코딩 자체가 안 된다.
- **왜 이번 PR 에 안 넣었나**: 정규식에 `u` 플래그를 들이는 일이라, 유효한 대리쌍(이모지)이
  쪼개지지 않는지 회귀 테스트가 따로 필요하다. 이 PR 범위(제어문자)를 넘는다.

#### 2. 숫자 표기가 갈린다 — `inf`·`nan` 은 양쪽 다 깨져 있다

- **위치**: `apps/web/src/canvas/variables.ts:263`
- **문제**: `1.0` → `1` ↔ `1.0`(타입이 갈린다), `-0.0` → `0` ↔ `-0.0`,
  `Infinity`/`NaN` ↔ `inf`/`nan` — **마지막은 양쪽 다 Python NameError 다.**
- **왜 이번 PR 에 안 넣었나**: 이번에 건드리지 않은 기존 코드이고, 백엔드 쌍둥이를 함께
  고쳐야 한다. **프런트만 고치면 갈라짐이 남는다.**
