### PR TITLE
fix: 노트북 툴바가 좁아지면 줄을 바꾼다

### DIFF
--- a/apps/web/src/components/Notebook.tsx
+++ b/apps/web/src/components/Notebook.tsx
@@ -1591,34 +1591,37 @@ export function Notebook({
     >
       <div className="nb-toolbar">
         {toolbarLeft}
-        <div className="nb-toolbar-spacer" />
-        <button className="btn sm" onClick={() => selectCommand(insertAt('sql', cells.length))} title="SQL 셀 추가">
-          <Icon.plus />
-          SQL 셀
-        </button>
-        <button className="btn sm" onClick={() => selectCommand(insertAt('md', cells.length))} title="메모 셀 추가">
-          <Icon.note />
-          메모 셀
-        </button>
-        <span className="nb-toolbar-div" />
-        <button className="btn sm" onClick={() => cells.filter((c) => c.type === 'sql').forEach((c) => apiRef.current.get(c.id)?.run())} title="모든 SQL 셀 실행">
-          <Icon.play />
-          전체 실행
-        </button>
-        <button className="btn sm" onClick={resetSession} title="세션 초기화 — 실행 번호와 모든 셀 출력을 지웁니다">
-          <Icon.refresh />
-          세션 초기화
-        </button>
-        {onSave && (
-          <button className="btn sm" onClick={onSave} title="저장 (⌘/Ctrl+S) — 셀을 하나의 쿼리로 저장">
-            <Icon.save />
-            저장
+        {/* 오른쪽 동작은 한 덩어리다 — 좁아지면 통째로 다음 줄로 내려간다.
+            낱개로 두면 「저장」만 아래로 떨어지는 식으로 묶음이 갈라진다. */}
+        <div className="nb-toolbar-actions">
+          <button className="btn sm" onClick={() => selectCommand(insertAt('sql', cells.length))} title="SQL 셀 추가">
+            <Icon.plus />
+            SQL 셀
           </button>
-        )}
-        <span className="nb-help" title="Shift+Enter 실행·다음 · ⌘/Ctrl+Enter 실행 · Alt+Enter 실행·삽입 · Esc 커맨드 · Enter 편집 · A/B 위·아래 추가 · DD 삭제 · M/Y 메모·코드 · Z 되돌리기">
-          단축키 ⓘ
-        </span>
-        {viewToggle}
+          <button className="btn sm" onClick={() => selectCommand(insertAt('md', cells.length))} title="메모 셀 추가">
+            <Icon.note />
+            메모 셀
+          </button>
+          <span className="nb-toolbar-div" />
+          <button className="btn sm" onClick={() => cells.filter((c) => c.type === 'sql').forEach((c) => apiRef.current.get(c.id)?.run())} title="모든 SQL 셀 실행">
+            <Icon.play />
+            전체 실행
+          </button>
+          <button className="btn sm" onClick={resetSession} title="세션 초기화 — 실행 번호와 모든 셀 출력을 지웁니다">
+            <Icon.refresh />
+            세션 초기화
+          </button>
+          {onSave && (
+            <button className="btn sm" onClick={onSave} title="저장 (⌘/Ctrl+S) — 셀을 하나의 쿼리로 저장">
+              <Icon.save />
+              저장
+            </button>
+          )}
+          <span className="nb-help" title="Shift+Enter 실행·다음 · ⌘/Ctrl+Enter 실행 · Alt+Enter 실행·삽입 · Esc 커맨드 · Enter 편집 · A/B 위·아래 추가 · DD 삭제 · M/Y 메모·코드 · Z 되돌리기">
+            단축키 ⓘ
+          </span>
+          {viewToggle}
+        </div>
       </div>
       <div className="nb-body" ref={bodyRef} tabIndex={0} onKeyDown={onCommandKeys}>
         {cells.length === 0 && (

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -7525,9 +7525,21 @@ tbody tr:hover {
   padding: 8px 12px;
   border-bottom: 1px solid var(--line2);
   background: #fff;
+  /* 좁아지면 **줄을 바꾼다** (.sql-editor-toolbar 와 같은 규칙).
+     안 바꾸면 가장 잘 줄어드는 것 — 허용 명령 태그와 단축키 힌트 — 이 한 글자씩
+     세로로 쌓여 툴바가 몇 배로 높아지고 옆 버튼과 겹쳐 보인다. */
+  flex-wrap: wrap;
+  row-gap: 6px;
 }
-.nb-toolbar-spacer {
-  flex: 1;
+/* 오른쪽 동작 묶음 — 좁아지면 통째로 다음 줄로 내려간다.
+   낱개로 두면 「저장」만 아래로 떨어지는 식으로 묶음이 갈라져 어느 것이 한 벌인지 안 보인다. */
+.nb-toolbar-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  row-gap: 6px;
+  flex-wrap: wrap;
+  margin-left: auto;
 }
 .nb-toolbar-div {
   width: 1px;
@@ -7576,6 +7588,9 @@ tbody tr:hover {
   font-size: 11px;
   color: var(--muted);
   cursor: help;
+  /* 툴바가 한 줄일 때 이것부터 줄어들어 「단/축/키」로 쪼개졌다 — 줄 바꿈 대신 줄을 넘긴다. */
+  flex-shrink: 0;
+  white-space: nowrap;
 }
 .nb-md-placeholder {
   color: var(--muted);


### PR DESCRIPTION
## 변경 요약

노트북 툴바가 좁은 폭에서 무너지는 문제를 고친다.

- `.nb-toolbar` 에 `flex-wrap` 이 없어, 폭이 모자라면 줄을 바꾸는 대신 **가장 잘 줄어드는 것부터 짜부라졌다** — 허용 명령 태그(`.stmt-tags`)가 한 칸 폭 세로 기둥이 되고 「단축키 ⓘ」가 글자 단위로 쪼개져 옆 버튼과 겹쳐 보였다. 편집기 툴바(`.sql-editor-toolbar`)가 이미 쓰는 규칙(`flex-wrap` + `row-gap`)을 그대로 적용한다.
- `flex: 1` 스페이서를 없애고 오른쪽 동작을 `.nb-toolbar-actions`(`margin-left: auto`)로 묶는다. 스페이서만 두고 줄을 바꾸면 「저장」·「편집기」만 아래로 떨어져 묶음이 갈라진다 — 통째로 내려가야 어느 것이 한 벌인지 보인다.
- `.nb-help` 에 `flex-shrink: 0` · `white-space: nowrap` — 툴바가 한 줄일 때 이것부터 줄어들어 「단/축/키」로 쪼개졌다.

CSS·마크업만 바뀌었고 핸들러·props·로직은 그대로다.

## 테스트 방법

```bash
cd apps/web && npm test        # 18 files / 369 tests 통과
cd apps/web && npm run lint    # 통과
cd apps/web && npm run build   # 통과
```

시각 검증은 실제 `styles.css` 와 같은 마크업으로 만든 하니스를 브라우저에 띄워 폭별 툴바 높이를 실측했다(`getBoundingClientRect`).

| 폭 | 수정 전 | 수정 후 |
|---|---|---|
| 1200px | 61px | 89px (2줄) |
| 980px | 85px | 89px (2줄) |
| 860px | **205px** | 89px (2줄) |
| 760px | **229px** | 89px (2줄) |
| 520px | **229px** | 131px (3줄) |

## 알아 둘 점

태그가 9개 다 켜진 연결이면 툴바 내용 폭이 ~1230px 라 **1200px 에서도 2줄이 된다.** 짜부라뜨리는 대신 정직하게 줄을 늘리는 쪽을 택한 결과다. 넓은 화면에서도 한 줄을 유지하려면 좁을 때 「단축키 ⓘ」를 숨기거나 태그를 접는(`+4`) 방식이 따로 필요하다 — 이 PR 범위 밖이다.
