### PR TITLE
chore(deps): vite 짝의 나머지 구멍(coverage-v8·plugin-react)을 잠근다

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,14 +32,15 @@ updates:
       prod-dependencies:
         dependency-type: production
         update-types: [minor, patch]
-    # 아래 여덟은 **메이저만** 뺀다. 마이너·패치는 위 그룹으로 그대로 온다.
-    # 여덟 모두 "이것 하나만 올리면 안 되는" 것들이라 갱신이 아니라 결정이다.
+    # 아래 열은 **메이저만** 뺀다. 마이너·패치는 위 그룹으로 그대로 온다.
+    # 열 모두 "이것 하나만 올리면 안 되는" 것들이라 갱신이 아니라 결정이다.
     #
-    # 되돌릴 때 주의 — **세 건은 절차가 하나 더 있다.** 첫 주기 정리 중 #57(@types/node)·
-    # #58(vitest)·#59(typescript) 에 `@dependabot ignore this major version` 코멘트도 함께
-    # 보냈고, 그쪽은 저장소에 보이지 않는 Dependabot 내부 상태다. 그 셋은 아래 설정을
-    # 지우는 것만으로 갱신이 돌아오지 않는다 — `@dependabot unignore ...` 를 함께 보내야
-    # 하고, 안 그러면 설정은 고쳤는데 PR 만 안 오는, 원인을 못 찾는 상태가 된다.
+    # 되돌릴 때 주의 — **다섯 건은 절차가 하나 더 있다.** 첫 주기 정리 중 #57(@types/node)·
+    # #58(vitest)·#59(typescript) 에, 그리고 이번에 #103(@vitest/coverage-v8)·
+    # #104(@vitejs/plugin-react) 를 닫으면서 `@dependabot ignore this major version`
+    # 코멘트도 함께 보냈고, 그쪽은 저장소에 보이지 않는 Dependabot 내부 상태다. 그 다섯은
+    # 아래 설정을 지우는 것만으로 갱신이 돌아오지 않는다 — `@dependabot unignore ...` 를
+    # 함께 보내야 하고, 안 그러면 설정은 고쳤는데 PR 만 안 오는, 원인을 못 찾는 상태가 된다.
     # 나머지 다섯(vite · react 4형제)은 그런 코멘트가 없어 설정만 지우면 된다.
     ignore:
       # vitest 는 자체 vite 를 번들한다 — vite 메이저와 맞춰야 타입이 충돌하지 않는다
@@ -49,6 +50,29 @@ updates:
       - dependency-name: vitest
         update-types: [version-update:semver-major]
       - dependency-name: vite
+        update-types: [version-update:semver-major]
+      # 이 둘도 **같은 짝의 나머지 구성원**이다 — 위 vitest·vite 만 잠그고 이 둘을 열어
+      # 두었더니 그 구멍으로 PR #103·#104 가 들어왔다.
+      #
+      # `@vitest/coverage-v8` 의 peer 는 `vitest` 와 **정확히 같은 버전**이다
+      # (4.1.11 은 `vitest@4.1.11` 을 요구). vitest 를 잠근 채 이쪽만 열어 두면 반드시
+      # `ERESOLVE` 로 막힌 PR 이 온다 — #103 이 실제로 `npm ci` 단계에서 그렇게 실패했다.
+      #
+      # `@vitejs/plugin-react` 는 vite 메이저에 묶인다. **6.1.1 의 peer 는 `vite@^8.0.0`**
+      # 이고 우리는 vite ^6.0.1 이라 #104 가 `ERESOLVE` 로 막혔다. #68 이 「plugin-react
+      # 4 → 6」이라 적을 때 근거였던 #77 시점에는 vite 7 이면 됐지만, **지금 6.1.1 은
+      # vite 8 을 요구한다** — #68 의 목표 버전 자체가 낡았다. (참고: `@vitejs/plugin-
+      # react@5.2.0` 은 `vite ^4.2 || ^5 || ^6 || ^7 || ^8` 이라 vite 6 에서도 돌지만,
+      # 짝을 따로 움직이지 않는다는 이 파일의 원칙에 따라 그것도 #68 에서 함께 정한다.)
+      #
+      # 넷(vitest·vite·coverage-v8·plugin-react)을 함께 올리는 것도 #68 이 추적한다.
+      # 되돌릴 때 주의: 이 둘도 `@dependabot ignore this major version` 코멘트가 남는다
+      # (#103·#104 를 닫으며 함께 보냈다) — 설정만 지우면 안 돌아오고
+      # `@dependabot unignore @vitest/coverage-v8` · `@dependabot unignore
+      # @vitejs/plugin-react` 를 함께 보내야 한다 (머리말의 "다섯 건" 목록 참조).
+      - dependency-name: "@vitest/coverage-v8"
+        update-types: [version-update:semver-major]
+      - dependency-name: "@vitejs/plugin-react"
         update-types: [version-update:semver-major]
       # @types/node 가 하는 일은 "이 런타임에 무엇이 있는가"를 tsc 에 알려 주는 것이다.
       # 런타임보다 앞서면 Node 26 에만 있는 API 를 tsc 가 통과시키고 컨테이너에서 터진다 —


### PR DESCRIPTION
## 무엇을 바꿨나

`.github/dependabot.yml` 의 npm 항목에 `@vitest/coverage-v8` · `@vitejs/plugin-react` 의 **메이저 갱신 제외**를 추가한다. 설정 파일 주석만 바뀌고 `apps/web` 은 한 줄도 손대지 않는다.

## 왜

이 파일은 이미 `vitest` · `vite` 메이저를 잠가 두었고, 그 주석이 이유를 이렇게 못박고 있다.

> **짝이므로 양쪽 다 뺀다.** 한쪽만 잠그면 반대쪽이 단독 메이저 PR 로 올라와 같은 짝을 반대 방향에서 깬다 — 잠그는 의미가 없어진다.

그런데 그 짝의 나머지 두 구성원이 목록에 없었다. 2026-08-31 주기에 정확히 그 구멍으로 둘이 들어왔고, 둘 다 `npm ci` 단계에서 `ERESOLVE` 로 막혔다.

- #103 `@vitest/coverage-v8` 3.2.7 → 4.1.11 — 이 패키지의 peer 는 `vitest` 와 **정확히 같은 버전**이다 (`peer vitest@"4.1.11"`). vitest 를 잠근 채 이쪽만 열어 두면 반드시 막힌 PR 이 온다.
- #104 `@vitejs/plugin-react` 4.7.0 → 6.1.1 — **6.1.1 의 peer 는 `vite@^8.0.0`** 이다. 우리는 `vite ^6.0.1`.

넷을 함께 올리는 일은 #68 이 추적한다. 이 PR 은 그 결정을 앞당기지 않고, **결정 없이 흘러드는 것만 막는다.**

### #68 에 반영이 필요한 사실 두 가지

1. **목표 버전이 낡았다.** #68 은 「vite 6 → 7 · plugin-react 4 → 6」이라 적었는데, 그 근거였던 #77 시점과 달리 지금 `plugin-react@6.1.1` 은 vite **8** 을 요구한다. (`@vitejs/plugin-react@5.2.0` 은 `vite ^4.2 || ^5 || ^6 || ^7 || ^8` 이라 vite 6 에서도 돌지만, 짝을 따로 움직이지 않는다는 이 파일의 원칙에 따라 그것도 #68 에서 함께 정한다.)
2. **진짜 비용은 API 호환이 아니라 커버리지다.** 이 PR 을 내기 전에 vitest 3→4 · coverage-v8 3→4 · plugin-react 4→5.2.0 을 실제로 올려 끝까지 돌려 봤다. 자세한 수치는 #68 에 코멘트로 남긴다.

## 확인한 것

```bash
python3 -c "import yaml; yaml.safe_load(open('.github/dependabot.yml'))"   # 통과
git diff origin/main -- apps/web                                          # 0줄
```

- [x] 바꾼 영역의 테스트·린트·타입체크가 통과한다 — 설정 파일 한 개라 해당 테스트가 없다. YAML 파싱으로 갈음했다
- [ ] 변경한 화면/경로를 실제로 실행해 확인했다 — 화면 변경 없음

Dependabot 설정은 머지되어 기본 브랜치에 올라간 뒤 다음 주기부터 적용된다 — 이 PR 의 CI 로는 확인할 수 없는 종류다.

## 되돌릴 때 주의

#103 · #104 를 닫으면서 `@dependabot ignore this major version` 코멘트를 함께 보냈다. 이것은 **저장소에 보이지 않는 Dependabot 내부 상태**라, 나중에 #68 을 진행하며 이 설정을 지우는 것만으로는 갱신이 돌아오지 않는다. `@dependabot unignore @vitest/coverage-v8` · `@dependabot unignore @vitejs/plugin-react` 를 함께 보내야 한다. 이 절차는 파일 머리말의 목록에도 적어 두었다.

## 체크리스트

- [x] 근거 이슈가 있으면 본문 맨 위에 `Closes #N` 을 적었다 — 없어서 지웠다. 이 PR 은 #68 을 **닫지 않는다** (그 결정을 미루고 잠글 뿐이다)
- [x] 커밋을 영역별로 분리했다 — 커밋 하나, 영역 하나(`.github/`)
