### PR TITLE
fix(web): zod 4 로 올리며 z.record 2인자 계약과 ZodTypeAny 를 맞춘다

### DIFF
--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -22,7 +22,7 @@
         "react-hook-form": "^7.86.0",
         "react-router-dom": "^7.18.3",
         "recharts": "^3.10.1",
-        "zod": "^3.23.8",
+        "zod": "^4.5.4",
         "zustand": "^5.0.15"
       },
       "devDependencies": {
@@ -5931,9 +5931,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.5.4.tgz",
+      "integrity": "sha512-sC95tT5iHHH9gtpj6A81kh+NEaRAUFN+qlUPDUbRfOMvNf5QCBqsb3WgvnpVtK5Y+4UfA6KqufotuTvMGiTlsA==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -28,7 +28,7 @@
     "react-hook-form": "^7.86.0",
     "react-router-dom": "^7.18.3",
     "recharts": "^3.10.1",
-    "zod": "^3.23.8",
+    "zod": "^4.5.4",
     "zustand": "^5.0.15"
   },
   "devDependencies": {

--- a/apps/web/src/api/client.test.ts
+++ b/apps/web/src/api/client.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, expectTypeOf, it, vi } from 'vitest'
 import { z } from 'zod'
 import { ApiError, api, runStreamUrl } from './client'
 
@@ -82,6 +82,13 @@ describe('api.parsed', () => {
     vi.spyOn(console, 'error').mockImplementation(() => {})
     mockFetch(200, { id: 123 })
     await expect(api.parsed(schema, '/runs/run-1')).rejects.toThrow('응답 형식이 올바르지 않습니다')
+  })
+
+  it('타입 수준에서도 .default() 필드는 optional 로 새지 않는다 (client.ts 의 z.ZodType 함정 회귀 방지)', async () => {
+    mockFetch(200, { id: 'run-1' })
+    const result = await api.parsed(schema, '/runs/run-1')
+    // 컴파일 시점 검증 — records·error 가 optional(`?`)이면 여기서 tsc 가 실패한다.
+    expectTypeOf(result).toEqualTypeOf<{ id: string; records: number; error: string | null }>()
   })
 })
 

--- a/apps/web/src/api/client.ts
+++ b/apps/web/src/api/client.ts
@@ -80,8 +80,11 @@ async function request(path: string, options: RequestOptions = {}): Promise<unkn
  *
  * 제네릭을 스키마 자체로 받는 것이 중요하다 — `z.ZodType<T>` 로 받으면 TS 가 T 를
  * 출력이 아닌 **입력** 타입으로 추론해 `.default()` 필드가 전부 optional 로 새어 나온다.
+ * (zod 4: `z.ZodTypeAny` 는 deprecated — `z.ZodType`(제네릭 없이, bare)가 그 자리를
+ * 대체한다. `z.ZodType<T>` 처럼 출력 타입을 박아 넣으면 zod 3 과 같은 함정이 그대로다.
+ * 실제로 회귀 여부는 `client.test.ts` 의 타입 단언이 `tsc` 로 지킨다.)
  */
-async function parsed<S extends z.ZodTypeAny>(
+async function parsed<S extends z.ZodType>(
   schema: S,
   path: string,
   options?: RequestOptions,

--- a/apps/web/src/api/types.ts
+++ b/apps/web/src/api/types.ts
@@ -59,7 +59,7 @@ export const pipelineNodeSchema = z.object({
   kind: nodeKindSchema,
   label: z.string().default(''),
   position: z.object({ x: z.number(), y: z.number() }).default({ x: 0, y: 0 }),
-  params: z.record(z.unknown()).default({}),
+  params: z.record(z.string(), z.unknown()).default({}),
 })
 export type PipelineNode = z.infer<typeof pipelineNodeSchema>
 
@@ -75,7 +75,7 @@ export type PipelineEdge = z.infer<typeof pipelineEdgeSchema>
 export const pipelineDefinitionSchema = z.object({
   nodes: z.array(pipelineNodeSchema).default([]),
   edges: z.array(pipelineEdgeSchema).default([]),
-  variables: z.record(z.unknown()).default({}),
+  variables: z.record(z.string(), z.unknown()).default({}),
 })
 export type PipelineDefinition = z.infer<typeof pipelineDefinitionSchema>
 
@@ -84,7 +84,7 @@ export const connectionSchema = z.object({
   name: z.string(),
   type: z.string(),
   description: z.string().nullable().default(null),
-  config: z.record(z.unknown()).default({}),
+  config: z.record(z.string(), z.unknown()).default({}),
   pool_size: z.number().default(5),
   ssl: z.boolean().default(false),
   cdc_enabled: z.boolean().default(false),
@@ -157,7 +157,7 @@ export const objectDetailSchema = z.object({
   columns: z.array(columnSchema).default([]),
   indexes: z.array(indexSchema).default([]),
   definition: z.string().nullable().default(null),
-  info: z.record(z.string()).default({}),
+  info: z.record(z.string(), z.string()).default({}),
 })
 export type ObjectDetail = z.infer<typeof objectDetailSchema>
 
@@ -183,14 +183,14 @@ export const deleteResultSchema = z.object({
 
 export const previewSchema = z.object({
   columns: z.array(z.string()),
-  rows: z.array(z.record(z.unknown())),
+  rows: z.array(z.record(z.string(), z.unknown())),
   truncated: z.boolean().default(false),
 })
 export type Preview = z.infer<typeof previewSchema>
 
 export const queryResultSchema = z.object({
   columns: z.array(z.string()),
-  rows: z.array(z.record(z.unknown())),
+  rows: z.array(z.record(z.string(), z.unknown())),
   row_count: z.number(),
   truncated: z.boolean().default(false),
   elapsed_ms: z.number(),
@@ -319,7 +319,7 @@ export const runSchema = z.object({
   records: z.number().default(0),
   progress: z.number().default(0),
   error: z.string().nullable().default(null),
-  node_states: z.record(z.unknown()).default({}),
+  node_states: z.record(z.string(), z.unknown()).default({}),
   created_at: z.string(),
 })
 export type Run = z.infer<typeof runSchema>
@@ -374,7 +374,7 @@ export type Stats = z.infer<typeof statsSchema>
 export const runEventSchema = z.object({
   type: z.enum(['snapshot', 'status', 'progress', 'log', 'node']),
   run_id: z.string().optional(),
-  payload: z.record(z.unknown()).default({}),
+  payload: z.record(z.string(), z.unknown()).default({}),
   ts: z.string().optional(),
 })
 export type RunEvent = z.infer<typeof runEventSchema>
@@ -382,7 +382,7 @@ export type RunEvent = z.infer<typeof runEventSchema>
 /** 노드 실행 결과 샘플 (엣지 위 미리보기) */
 export const nodeSampleSchema = z.object({
   columns: z.array(z.string()).default([]),
-  rows: z.array(z.record(z.unknown())).default([]),
+  rows: z.array(z.record(z.string(), z.unknown())).default([]),
   truncated: z.boolean().default(false),
 })
 export type NodeSample = z.infer<typeof nodeSampleSchema>
@@ -395,10 +395,10 @@ export const nodeStateSchema = z.object({
   location: z.string().nullable().default(null),
   sample: nodeSampleSchema.optional(),
   /** API 트리거가 선으로 넘긴 **값 그 자체** {이름: 값} — 엣지 칩에 뜨는 것이 이것이다. */
-  handed: z.record(z.unknown()).optional(),
+  handed: z.record(z.string(), z.unknown()).optional(),
   /** 그 값으로 하류 노드 설정이 어떻게 바뀌었는지 {하류_노드_id: {파라미터: 치환된 값}}.
    *  엣지 상세 모달에서 저작↔실행 대비에 쓴다. 트리거 노드에만 있다. */
-  applied: z.record(z.record(z.unknown())).optional(),
+  applied: z.record(z.string(), z.record(z.string(), z.unknown())).optional(),
 })
 export type NodeState = z.infer<typeof nodeStateSchema>
 
@@ -415,9 +415,9 @@ export const cdcStreamSchema = z.object({
   source_connection_id: z.string().nullable().default(null),
   target_connection_id: z.string().nullable().default(null),
   topics: z.array(z.string()).default([]),
-  config: z.record(z.unknown()).default({}),
+  config: z.record(z.string(), z.unknown()).default({}),
   last_event_at: z.string().nullable().default(null),
-  metrics: z.record(z.unknown()).default({}),
+  metrics: z.record(z.string(), z.unknown()).default({}),
   error: z.string().nullable().default(null),
   created_at: z.string(),
   updated_at: z.string(),


### PR DESCRIPTION
## 무엇을 바꿨나

`zod` 3.25.76 → **4.5.4**. Dependabot [#117](https://github.com/SurvivorsStudio/ditter/pull/117) 을 대체한다 — 그쪽은 `package.json` 만 올려서 `tsc -b` 가 15건의 오류로 깨졌다. 여기서는 **코드까지 함께 고쳐** 통과시킨다.

## 왜

### 1. `z.record` 가 2인자 필수가 됐다 (14곳)

zod 4 는 `z.record(키스키마, 값스키마)` 를 요구한다. 단일 인자 형태가 전부 `TS2554: Expected 2-3 arguments, but got 1` 로 떨어졌다.

**zod 3 에서의 의미를 그대로 보존하는 것이 이 변경의 전부다.**

| zod 3 | 뜻 | zod 4 |
|---|---|---|
| `z.record(z.unknown())` | `Record<string, unknown>` | `z.record(z.string(), z.unknown())` |
| `z.record(z.string())` | `Record<string, string>` | `z.record(z.string(), z.string())` |

두 번째가 함정이다 — 원래의 **값** 스키마를 **키** 자리에 그대로 밀어 넣으면 타입은 통과하는데 검증 계약이 뒤집힌다. `info: z.record(z.string())`(types.ts:160) 한 곳이 여기 해당했고, 값 스키마를 `z.string()` 으로 따로 적어 줬다.

중첩된 곳도 하나 있다 — `applied: z.record(z.record(z.unknown()))` → `z.record(z.string(), z.record(z.string(), z.unknown()))`.

`types.ts:218` 은 **이미 2인자 형태**였다. 새 스타일을 들여온 게 아니라 나머지를 거기 맞춘 것이다.

### 2. `ObjectDetailModal.tsx` 오류는 별건이 아니었다

15번째 오류(`TS2322: Type 'unknown' is not assignable to type 'ReactNode'`)는 `data.info` 의 값 타입이 `unknown` 으로 떨어진 결과였고, 위 `info` 수정만으로 **저절로 사라졌다.** 그래서 그 파일은 건드리지 않았다 — `String(v)` 로 덮었으면 원인을 가린 채 증상만 지웠을 것이다.

### 3. `z.ZodTypeAny` — `tsc` 가 오류를 안 내서 조용히 방치될 뻔한 자리

`client.ts:84` 의 `parsed<S extends z.ZodTypeAny>` 는 CLAUDE.md §14 가 "여기서 데였다"고 적어 둔 곳이다.

> 제네릭을 스키마 자체로 받는 것이 중요하다 — `z.ZodType<T>` 로 받으면 TS 가 T 를 출력이 아닌 **입력** 타입으로 추론해 `.default()` 필드가 전부 optional 로 새어 나온다.

zod 4 에서 `ZodTypeAny` 는 **deprecated**(`ZodType` 의 단순 별칭)다. deprecated 는 `tsc` 오류가 아니라 그냥 두면 빌드가 통과한다 — 방치되기 딱 좋은 모양이라 지금 정리했다. `z.ZodType`(제네릭 없이)로 바꾸고 주석도 함께 갱신했다.

**그리고 그 함정이 zod 4 에서도 유효한지 실제로 확인했다.** `client.test.ts` 에 타입 단언을 넣었다.

```ts
expectTypeOf(result).toEqualTypeOf<{ id: string; records: number; error: string | null }>()
```

지금까지 이 성질을 지키는 것은 **사람이 읽는 주석 한 줄뿐**이었다. 이제 `tsc` 가 지킨다.

### 4. `tsc` 가 실제로 잡는지 검증했다

`expectTypeOf` 는 `vitest --typecheck` 없이는 런타임에 no-op 이라, "타입 테스트를 넣었다"가 곧 "보호된다"는 아니다. 그래서 **일부러 깨뜨려 확인했다** — `records: number` 를 `records?: number` 로 바꾸고 `npm run build` 를 돌렸다.

```
src/api/client.test.ts(91,40): error TS2344: Type '{ id: string; records?: number | undefined; ... }'
  does not satisfy the constraint '... records?: "Expected: number, Actual: never" | ...'
```

`tsconfig.app.json` 의 `include: ["src"]` 가 테스트 파일까지 덮어서 `tsc -b` 대상에 들어간다(`tsc -b --listFiles` 로 확인). 확인 후 원복했다.

### 5. 런타임 의미 변화는 없다

zod 4 의 나머지 breaking change 를 훑었고, 이 저장소에는 닿지 않는다.

- **`.default()` 재파싱 중단** (예전 동작은 `.prefault()`) — 이 저장소의 default 값은 `{}` · `[]` · `null` · 원시값뿐이라 재파싱 유무가 결과를 바꾸지 않는다
- **문자열 포맷이 최상위 함수로 이동** (`z.string().email()` → `z.email()`) — 쓰는 곳이 없다
- **에러 표면** — `.error.errors` 를 쓰는 곳이 없다. `client.ts:92` 는 이미 `.error.issues` 라 zod 4 형태였다

## 확인한 것

```bash
cd apps/web && npm test && npm run test:coverage && npm run lint && npm run build
```

네 명령 전부 **exit 0**. 테스트 **382 passed** (기존 381 + 신규 타입 단언 1), 18 파일. 설치된 zod 가 실제로 4.5.4 인 것도 확인했다. **커버리지 하한은 건드리지 않았다.**

- [x] 바꾼 영역의 테스트·린트·타입체크가 통과한다
- [ ] 변경한 화면/경로를 실제로 실행해 확인했다 — **브라우저로 띄워 보지는 않았다.** 응답 검증 스키마 변경이라 화면에 나타난다면 "데이터가 안 뜬다" 형태일 텐데, `z.record` 의 키/값 의미를 보존했고 파싱 경로는 기존 테스트가 덮는다

## 남는 것

CLAUDE.md §14 의 zod 항목이 `z.ZodTypeAny` 를 권장 형태로 적고 있어 이제 낡았다. 문서 갱신은 이 PR 에 넣지 않았다 — 별도로 처리한다.

## 체크리스트

- [x] `Closes #N` — 이 PR 은 이슈를 닫지 않아 그 줄을 지웠다. Dependabot PR #117 을 대체한다
- [x] 커밋을 영역별로 분리했다 — 커밋 하나, web 하나
