### PR TITLE
fix(web): 없는 경로에 404 화면을 두고 머리글이 거짓말하지 않게 한다

### DIFF
--- a/apps/web/src/App.heading.test.ts
+++ b/apps/web/src/App.heading.test.ts
@@ -6,6 +6,9 @@ import { headingFor } from './App'
  *  예전에는 홈이 `/^\//` 라 **모든 경로에** 맞았다. 없는 주소로 가면 본문은 비어 있는데
  *  머리글만 「대시보드」로 남아, 경로가 틀린 것이 아니라 홈이 깨진 것으로 보였다.
  *  화면을 봐야만 드러나는 종류라 여기서 못박는다.
+ *
+ *  아래 경로별 기대값은 **`App.tsx` 의 `<Routes>` 가 실제로 무엇을 렌더링하는지**에 맞춘 것이다
+ *  (react-router `matchRoutes` 로 확인). 머리글 규칙이 라우트보다 넓어지면 본문과 갈린다.
  */
 describe('headingFor', () => {
   it('알려진 경로는 그 화면의 머리글이다', () => {
@@ -22,6 +25,24 @@ describe('headingFor', () => {
       expect(headingFor(path).title, path).toBe('nav.title.notFound')
       expect(headingFor(path).crumb, path).toBe('nav.crumb.notFound')
     }
+  })
+
+  it('한 칸 더 들어간 주소는 라우트가 없으므로 「찾을 수 없음」이다', () => {
+    // 전에는 `/^\/sql(\/|$)/` 라 여기서 머리글만 「SQL」로 남았다 — 본문은 404 인데.
+    // `<Route path="/sql">` 은 `/sql` 하나만 잡는다(`/sql/foo` 는 `path="*"` 로 간다).
+    for (const path of ['/sql/foo', '/monitor/1', '/connections/2', '/canvas/p1/x']) {
+      expect(headingFor(path).title, path).toBe('nav.title.notFound')
+      expect(headingFor(path).crumb, path).toBe('nav.crumb.notFound')
+    }
+  })
+
+  it('꼬리 슬래시는 라우터가 무시하므로 머리글도 같아야 한다', () => {
+    // 좁히면서 이쪽으로 어긋나면 방향만 뒤집힌 같은 버그다 — 본문은 그 화면인데 머리글만 404.
+    expect(headingFor('/canvas/').title).toBe('nav.title.canvas')
+    expect(headingFor('/canvas/p1/').title).toBe('nav.title.canvas')
+    expect(headingFor('/sql/').title).toBe('nav.title.sql')
+    expect(headingFor('/monitor/').title).toBe('nav.title.monitor')
+    expect(headingFor('/connections/').title).toBe('nav.title.connections')
   })
 
   it('홈은 정확히 "/" 일 때만이다', () => {

--- a/apps/web/src/App.heading.test.ts
+++ b/apps/web/src/App.heading.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+import { headingFor } from './App'
+
+/** 경로 → 상단 머리글.
+ *
+ *  예전에는 홈이 `/^\//` 라 **모든 경로에** 맞았다. 없는 주소로 가면 본문은 비어 있는데
+ *  머리글만 「대시보드」로 남아, 경로가 틀린 것이 아니라 홈이 깨진 것으로 보였다.
+ *  화면을 봐야만 드러나는 종류라 여기서 못박는다.
+ */
+describe('headingFor', () => {
+  it('알려진 경로는 그 화면의 머리글이다', () => {
+    expect(headingFor('/').title).toBe('nav.title.home')
+    expect(headingFor('/canvas').title).toBe('nav.title.canvas')
+    expect(headingFor('/canvas/p1').title).toBe('nav.title.canvas')
+    expect(headingFor('/sql').title).toBe('nav.title.sql')
+    expect(headingFor('/monitor').title).toBe('nav.title.monitor')
+    expect(headingFor('/connections').title).toBe('nav.title.connections')
+  })
+
+  it('없는 경로는 홈이 아니라 「찾을 수 없음」이다', () => {
+    for (const path of ['/nonexistent-route', '/canvasx', '/sqlite', '/한글', '/a/b/c']) {
+      expect(headingFor(path).title, path).toBe('nav.title.notFound')
+      expect(headingFor(path).crumb, path).toBe('nav.crumb.notFound')
+    }
+  })
+
+  it('홈은 정확히 "/" 일 때만이다', () => {
+    // `/^\/$/` 가 아니라 `/^\//` 로 되돌리면 이 단언이 깨진다 — 그게 원래 버그였다.
+    expect(headingFor('/x').title).not.toBe('nav.title.home')
+  })
+})

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -16,19 +16,36 @@ import { SqlEditorPage } from './pages/SqlEditor'
 
 /** 경로 → 상단 머리글. **아래 `<Routes>` 와 짝이다 — 라우트를 더하면 여기도 더한다.**
  *
- *  마지막 두 줄의 순서가 중요하다. 예전에는 홈이 `/^\//` 였는데 그것이 **모든 경로에**
- *  맞아서, 없는 주소로 가도 머리글이 「대시보드」로 남았다. 본문은 비어 있는데 화면은
- *  "홈에 있다"고 말하니, 경로가 틀린 것이 아니라 홈이 깨진 것으로 보였다.
- *  홈은 `/^\/$/` 로 **정확히 `/` 일 때만** 잡고, 나머지는 아래 catch-all 이 받는다.
+ *  **각 규칙은 짝이 되는 `<Route path>` 와 정확히 같은 모양**이어야 한다. 넓게 잡으면
+ *  본문과 머리글이 갈리고, 그 어긋남은 언제나 한 방향으로 온다 — 본문은 404 인데
+ *  머리글은 "여기 있다"고 말한다.
  *
- *  나머지도 `(\/|$)` 로 경계를 둔다. 없으면 `/canvasx` 같은 오타가 `/^\/canvas/` 에 걸려
- *  **본문은 404 인데 머리글만 「파이프라인 편집기」** 가 된다 — 위와 똑같은 종류의 거짓말이다.
+ *  두 번 데였다. 처음엔 홈이 `/^\//` 라 **모든 경로에** 맞아 없는 주소에서도 머리글이
+ *  「대시보드」였고(경로가 틀린 것이 아니라 홈이 깨진 것으로 보였다), 다음엔 접두 매칭이
+ *  라우트보다 넓어 `/canvasx`·`/sql/foo`·`/monitor/1` 이 각 섹션 이름을 달고 나왔다.
+ *  React Router 는 `path="/sql"` 을 `/sql` 하나로만 본다 — `/sql/foo` 는 `path="*"` 로
+ *  떨어진다. 그래서 여기도 `$` 로 닫는다.
+ *
+ *  **끝의 `\/?` 는 장식이 아니다.** 라우터는 꼬리 슬래시를 무시해 `/sql/` 도 `path="/sql"`
+ *  로 본다. 이것을 빼면 `/sql/` 에서 본문은 SQL 편집기인데 머리글만 「찾을 수 없음」이 되어,
+ *  방금 없앤 거짓말이 방향만 뒤집혀 되살아난다.
+ *
+ *  `/canvas` 만 뒤에 한 칸을 허용하는 것은 `<Route path="/canvas/:pipelineId">` 가 있어서다.
+ *  `[^/]+` 인 이유도 같다 — 라우트 파라미터는 한 칸이라 `/canvas/p1/x` 는 라우트가 없다.
+ *
+ *  마지막 `/^\//` 는 catch-all 이라 **반드시 맨 뒤**여야 한다.
+ *
+ *  슬래시를 겹쳐 친 주소(`//`·`/canvas//`)는 여기서 catch-all 로 떨어지지만 라우터는 홈·캔버스로
+ *  본다 — 알고 남긴 어긋남이다. `pathname.replace(/\/{2,}/g, '/')` 로 눌러 맞추고 싶어지는데,
+ *  그러면 라우터가 `*` 로 보내는 `/canvas//p1` 이 여기서만 「파이프라인 편집기」가 되어
+ *  더 흔한 자리에서 새 거짓말이 생긴다. 정말로 없애려면 `matchRoutes` 로 라우트 표를 하나로
+ *  합쳐야 하고, 그건 이 표의 문제가 아니라 구조의 문제다.
  */
 const TITLES: { match: RegExp; title: MsgKey; crumb: MsgKey }[] = [
-  { match: /^\/canvas(\/|$)/, title: 'nav.title.canvas', crumb: 'nav.crumb.canvas' },
-  { match: /^\/sql(\/|$)/, title: 'nav.title.sql', crumb: 'nav.crumb.sql' },
-  { match: /^\/monitor(\/|$)/, title: 'nav.title.monitor', crumb: 'nav.crumb.monitor' },
-  { match: /^\/connections(\/|$)/, title: 'nav.title.connections', crumb: 'nav.crumb.connections' },
+  { match: /^\/canvas(\/[^/]+)?\/?$/, title: 'nav.title.canvas', crumb: 'nav.crumb.canvas' },
+  { match: /^\/sql\/?$/, title: 'nav.title.sql', crumb: 'nav.crumb.sql' },
+  { match: /^\/monitor\/?$/, title: 'nav.title.monitor', crumb: 'nav.crumb.monitor' },
+  { match: /^\/connections\/?$/, title: 'nav.title.connections', crumb: 'nav.crumb.connections' },
   { match: /^\/$/, title: 'nav.title.home', crumb: 'nav.crumb.home' },
   { match: /^\//, title: 'nav.title.notFound', crumb: 'nav.crumb.notFound' },
 ]

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -5,21 +5,39 @@ import { useCreatePipeline } from './api/hooks'
 import { Banner, Spinner } from './components/common'
 import { Icon } from './components/icons'
 import { switchLocale, useLocale, useT, type MsgKey } from './i18n'
-import { queryClient } from './main'
+import { queryClient } from './api/queryClient'
 import { Canvas } from './pages/Canvas'
 import { Connections } from './pages/Connections'
 import { Home } from './pages/Home'
 import { Login } from './pages/Login'
 import { Monitor } from './pages/Monitor'
+import { NotFound } from './pages/NotFound'
 import { SqlEditorPage } from './pages/SqlEditor'
 
+/** 경로 → 상단 머리글. **아래 `<Routes>` 와 짝이다 — 라우트를 더하면 여기도 더한다.**
+ *
+ *  마지막 두 줄의 순서가 중요하다. 예전에는 홈이 `/^\//` 였는데 그것이 **모든 경로에**
+ *  맞아서, 없는 주소로 가도 머리글이 「대시보드」로 남았다. 본문은 비어 있는데 화면은
+ *  "홈에 있다"고 말하니, 경로가 틀린 것이 아니라 홈이 깨진 것으로 보였다.
+ *  홈은 `/^\/$/` 로 **정확히 `/` 일 때만** 잡고, 나머지는 아래 catch-all 이 받는다.
+ *
+ *  나머지도 `(\/|$)` 로 경계를 둔다. 없으면 `/canvasx` 같은 오타가 `/^\/canvas/` 에 걸려
+ *  **본문은 404 인데 머리글만 「파이프라인 편집기」** 가 된다 — 위와 똑같은 종류의 거짓말이다.
+ */
 const TITLES: { match: RegExp; title: MsgKey; crumb: MsgKey }[] = [
-  { match: /^\/canvas/, title: 'nav.title.canvas', crumb: 'nav.crumb.canvas' },
-  { match: /^\/sql/, title: 'nav.title.sql', crumb: 'nav.crumb.sql' },
-  { match: /^\/monitor/, title: 'nav.title.monitor', crumb: 'nav.crumb.monitor' },
-  { match: /^\/connections/, title: 'nav.title.connections', crumb: 'nav.crumb.connections' },
-  { match: /^\//, title: 'nav.title.home', crumb: 'nav.crumb.home' },
+  { match: /^\/canvas(\/|$)/, title: 'nav.title.canvas', crumb: 'nav.crumb.canvas' },
+  { match: /^\/sql(\/|$)/, title: 'nav.title.sql', crumb: 'nav.crumb.sql' },
+  { match: /^\/monitor(\/|$)/, title: 'nav.title.monitor', crumb: 'nav.crumb.monitor' },
+  { match: /^\/connections(\/|$)/, title: 'nav.title.connections', crumb: 'nav.crumb.connections' },
+  { match: /^\/$/, title: 'nav.title.home', crumb: 'nav.crumb.home' },
+  { match: /^\//, title: 'nav.title.notFound', crumb: 'nav.crumb.notFound' },
 ]
+
+/** 그 경로의 머리글. 마지막 항목이 catch-all 이라 `find` 는 언제나 무언가를 돌려준다 —
+ *  그래도 폴백을 두는 것은 위 목록을 손대다 catch-all 을 잃었을 때 화면이 죽지 않게 하려는 것이다. */
+export function headingFor(pathname: string): (typeof TITLES)[number] {
+  return TITLES.find((entry) => entry.match.test(pathname)) ?? TITLES[TITLES.length - 1]
+}
 
 export function App() {
   const location = useLocation()
@@ -27,8 +45,7 @@ export function App() {
   const [authed, setAuthed] = useState(auth.isAuthenticated)
   const t = useT()
   const locale = useLocale()
-  const heading =
-    TITLES.find((entry) => entry.match.test(location.pathname)) ?? TITLES[TITLES.length - 1]
+  const heading = headingFor(location.pathname)
 
   // 토큰이 만료돼 client 가 로그아웃시키면 즉시 로그인 화면으로 되돌린다
   useEffect(() => auth.subscribe(() => setAuthed(auth.isAuthenticated)), [])
@@ -118,6 +135,8 @@ export function App() {
           <Route path="/sql" element={<SqlEditorPage />} />
           <Route path="/monitor" element={<Monitor />} />
           <Route path="/connections" element={<Connections />} />
+          {/* 없는 경로. 이게 없으면 React Router 가 아무것도 렌더링하지 않아 본문만 빈다. */}
+          <Route path="*" element={<NotFound />} />
         </Routes>
       </div>
 

--- a/apps/web/src/api/queryClient.ts
+++ b/apps/web/src/api/queryClient.ts
@@ -1,0 +1,21 @@
+import { QueryClient } from '@tanstack/react-query'
+
+/** 앱 전역 쿼리 클라이언트.
+ *
+ *  **`main.tsx` 가 아니라 여기 사는 이유**가 있다. 언어 전환이 서버 문구를 다시 받아오려면
+ *  화면 밖(`i18n/switchLocale.ts`)에서도 이 객체를 만져야 하는데, 그것을 `main.tsx` 가
+ *  내보내면 `App`·`Login` 이 **앱 시작 파일을 거꾸로 임포트**하게 된다.
+ *
+ *  그 고리는 브라우저에서는 무해했다(클릭 시점에만 꺼내 쓰므로). 하지만 `App` 을 임포트하는
+ *  테스트를 만들자마자 `main.tsx` 가 통째로 실행되고 `#root 엘리먼트를 찾을 수 없습니다` 로
+ *  터졌다 — 화면 코드가 아니라 **테스트를 못 쓰게 만드는** 종류의 결합이었다.
+ */
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 5_000,
+      refetchOnWindowFocus: false,
+      retry: 1,
+    },
+  },
+})

--- a/apps/web/src/i18n/messages/nav.ts
+++ b/apps/web/src/i18n/messages/nav.ts
@@ -17,4 +17,14 @@ export const nav = {
   'nav.crumb.sql': ['SQL', 'SQL'],
   'nav.crumb.monitor': ['실행 이력', 'Run history'],
   'nav.crumb.connections': ['연결', 'Connections'],
+
+  // 없는 경로 (`<Route path="*">`). 머리글이 「대시보드」로 남으면 홈이 깨진 것처럼 보인다.
+  'nav.title.notFound': ['찾을 수 없음', 'Not found'],
+  'nav.crumb.notFound': ['없는 경로', 'Unknown path'],
+  'nav.notFound.title': ['그런 경로가 없습니다', 'No such page'],
+  'nav.notFound.body': [
+    '주소를 잘못 입력했거나, 예전 링크일 수 있습니다.',
+    'The address may be mistyped, or the link may be out of date.',
+  ],
+  'nav.notFound.goHome': ['홈으로 가기', 'Go to home'],
 } as const

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,21 +1,10 @@
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { QueryClientProvider } from '@tanstack/react-query'
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { BrowserRouter } from 'react-router-dom'
 import { App } from './App'
+import { queryClient } from './api/queryClient'
 import './styles.css'
-
-/** 언어 전환이 서버 문구를 다시 받아오려면 이 클라이언트를 화면 밖에서도 만져야 한다.
- *  (`i18n/switchLocale.ts` — App 레일·로그인 화면의 언어 버튼이 이것을 받는다) */
-export const queryClient = new QueryClient({
-  defaultOptions: {
-    queries: {
-      staleTime: 5_000,
-      refetchOnWindowFocus: false,
-      retry: 1,
-    },
-  },
-})
 
 const container = document.getElementById('root')
 if (!container) throw new Error('#root 엘리먼트를 찾을 수 없습니다')

--- a/apps/web/src/pages/Login.tsx
+++ b/apps/web/src/pages/Login.tsx
@@ -3,7 +3,7 @@ import { api } from '../api/client'
 import { auth, tokenResponseSchema } from '../api/auth'
 import { Banner, Spinner } from '../components/common'
 import { switchLocale, useLocale, useT } from '../i18n'
-import { queryClient } from '../main'
+import { queryClient } from '../api/queryClient'
 
 export function Login() {
   const [email, setEmail] = useState('')

--- a/apps/web/src/pages/NotFound.tsx
+++ b/apps/web/src/pages/NotFound.tsx
@@ -1,0 +1,34 @@
+import { NavLink, useLocation } from 'react-router-dom'
+import { EmptyState } from '../components/common'
+import { useT } from '../i18n'
+
+/** 없는 경로 — `<Route path="*">` 가 잡는다.
+ *
+ *  이 화면이 없으면 React Router 는 **아무것도 렌더링하지 않는다**(오류도 던지지 않는다).
+ *  껍데기(레일·상단바)만 남고 본문이 비어, 사용자에게는 경로가 틀린 것이 아니라
+ *  **화면이 깨진 것**으로 보인다. 그래서 여기서 "무엇이 없는지"를 말한다.
+ *
+ *  주소를 그대로 보여주는 이유는 오타를 눈으로 찾게 하려는 것이다 — 대개 한 글자다.
+ */
+export function NotFound() {
+  const t = useT()
+  const { pathname } = useLocation()
+
+  return (
+    <div className="view">
+      <div className="pad">
+        <EmptyState title={t('nav.notFound.title')}>
+          <p>
+            <code>{pathname}</code>
+          </p>
+          <p>{t('nav.notFound.body')}</p>
+          <p>
+            <NavLink to="/" className="btn primary">
+              {t('nav.notFound.goHome')}
+            </NavLink>
+          </p>
+        </EmptyState>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/pages/NotFound.tsx
+++ b/apps/web/src/pages/NotFound.tsx
@@ -1,4 +1,4 @@
-import { NavLink, useLocation } from 'react-router-dom'
+import { useLocation, useNavigate } from 'react-router-dom'
 import { EmptyState } from '../components/common'
 import { useT } from '../i18n'
 
@@ -12,6 +12,7 @@ import { useT } from '../i18n'
  */
 export function NotFound() {
   const t = useT()
+  const navigate = useNavigate()
   const { pathname } = useLocation()
 
   return (
@@ -22,11 +23,12 @@ export function NotFound() {
             <code>{pathname}</code>
           </p>
           <p>{t('nav.notFound.body')}</p>
-          <p>
-            <NavLink to="/" className="btn primary">
-              {t('nav.notFound.goHome')}
-            </NavLink>
-          </p>
+          {/* 링크가 아니라 버튼이다 — `.btn` 은 밑줄을 지우지 않아 앵커에 걸면 그것만 밑줄이
+              그어진다. 같은 상황의 기존 화면(`Canvas.tsx` 의 「파이프라인을 찾을 수 없습니다」)과
+              같은 모양으로 맞춘다. */}
+          <button className="btn primary" style={{ marginTop: 12 }} onClick={() => navigate('/')}>
+            {t('nav.notFound.goHome')}
+          </button>
         </EmptyState>
       </div>
     </div>


### PR DESCRIPTION
없는 경로로 들어가면 React Router 가 **아무것도 렌더링하지 않아** 레일·상단바만 남고 본문이
비었다. 오류도 던지지 않으므로 사용자에게는 "경로가 틀렸다"가 아니라 **"화면이 깨졌다"** 로
보인다. 게다가 머리글이 「대시보드」로 남아, 화면이 있지도 않은 자리를 가리켰다.

## 변경 요약

**404 화면을 둔다** (`pages/NotFound.tsx` 신규)
- `<Route path="*">` 가 잡는다. 기존 `EmptyState` 를 재사용해 같은 상황의 다른 화면
  (`Canvas.tsx` 의 「파이프라인을 찾을 수 없습니다」)과 모양을 맞춘다
- **주소를 그대로 보여준다** — 대개 오타 한 글자라 눈으로 찾게 하는 편이 빠르다

**머리글이 거짓말하지 않게 한다** (`App.tsx`)
- 홈이 `/^\//` 라 **모든 경로에** 맞고 있었다. `/^\/$/` 로 정확히 `/` 일 때만 잡는다
- 나머지 규칙도 짝이 되는 `<Route path>` 와 **정확히 같은 모양**으로 좁혔다. 접두 매칭이
  라우트보다 넓어 `/canvasx`·`/sql/foo`·`/monitor/1`·`/canvas/p1/x` 가 각 섹션 이름을 달고
  나왔다 — 본문은 404 인데 머리글만 「SQL」인, 이 PR 이 없애려던 것과 같은 어긋남이다
- 꼬리 슬래시(`\/?`)를 함께 받는다. 라우터는 `/sql/` 도 `path="/sql"` 로 보므로, 빼면 그
  거짓말이 **방향만 뒤집혀** 되살아난다(본문은 SQL 편집기인데 머리글만 「찾을 수 없음」)
- `headingFor()` 를 export 해 회귀 테스트를 붙였다

**`queryClient` 를 `api/queryClient.ts` 로 분리** (`main.tsx` → `api/`)
- 테스트가 `App.tsx` 를 불러오면 `main.tsx` 까지 딸려와 `#root` 를 찾다 죽었다. 화면 파일이
  진입점을 역참조하는 순환이라, 회귀 테스트를 붙이는 순간 드러났다
- 인스턴스는 그대로 하나다 — `QueryClientProvider` 와 `switchLocale` 이 같은 객체를 받는다

## 테스트 방법

```bash
cd apps/web && npx tsc -b --force && npm run lint && npm test && npm run build
```

- `tsc -b --force` exit 0 · `eslint --max-warnings 0` exit 0 · **403 tests / 22 files 통과**
  (신규 `App.heading.test.ts` 5건 포함) · `vite build` 성공 · `npm run test:coverage` 하한 통과
- `npx tsc --noEmit` 은 이 저장소에서 **아무것도 검사하지 않는다**(`files: []` + project
  references). 반드시 `tsc -b --force` 를 쓴다

수동 확인: `/canvasx`·`/sql/foo` 로 들어가 본문이 404 이고 머리글도 「찾을 수 없음」인지,
`/sql/` 에서는 반대로 SQL 편집기와 「SQL」이 함께 나오는지.

## 관련 이슈

Closes #92

## 코드리뷰

**이번 review 요약**: 1사이클, 확정 수정 2건 반영, 다음 PR 로 이월 2건.
반영된 것 중 하나는 P2 버그였다 — 이 PR 이 없애려던 어긋남이 한 단계 아래 경로
(`/sql/foo` 등)에서 그대로 재현되고 있었고, 초안의 테스트가 `/canvasx` 만 검사해 그 구멍을
덮지 못했다.

### 알려진 제약 사항 (이번 PR 미반영, 후속 검토 필요)

#### 1. 주소 목록이 여전히 두 곳에 있다 — `TITLES` 표와 `<Routes>`

- **위치**: `apps/web/src/App.tsx:44`
- **문제**: 제목을 고르는 표와 화면을 고르는 표가 따로 있어 손으로 맞춰야 한다. 주석의
  "라우트를 더하면 여기도 더한다"는 약속이 구조로 강제되지 않는다. 실제로 슬래시를 겹쳐 친
  주소(`//`·`/canvas//`)에서 둘이 갈린다 — 알고 남긴 어긋남이고 근거는 코드 주석에 있다.
  덧붙여 `headingFor` 가 화면 파일 안에 있어, 그 함수 하나를 테스트하려고 화면 전체를 불러온다.
- **왜 이번 PR 에 안 넣었나**: `matchRoutes` 로 라우트 표를 하나로 합치는 구조 변경이라
  `App.tsx` 변경 폭이 이 PR 의 범위를 넘는다. 좁은 수정으로 실제 버그부터 닫았다.

#### 2. 404 화면의 주소가 퍼센트 인코딩된 채로 보인다

- **위치**: `apps/web/src/pages/NotFound.tsx:22`
- **문제**: 한글·특수문자가 섞인 주소는 브라우저가 넘겨주는 형태 그대로
  (`/%ED%95%9C%EA%B8%80`) 뜬다. "오타를 눈으로 찾게 한다"는 이 화면의 목적이 그만큼 약해진다.
  (보안 문제는 없다 — React 가 이스케이프한다.)
- **왜 이번 PR 에 안 넣었나**: 고치는 방법 자체에 위험이 있다. `%` 하나만 든 주소처럼
  되돌릴 수 없는 값에서 `decodeURIComponent` 가 던지면 **404 화면 자체가 죽는다** —
  실패를 감싸는 형태로만 넣어야 해서, 필요를 판단한 뒤 별도로 다루는 편이 낫다.
